### PR TITLE
Simplify quick links and enable caching

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,51 +13,38 @@
 <main>
 <h3>Quick links</h3>
 <ul class="quick-links">
-  <li>
-    <img src="/assets/arrowright.gif" alt=">" class="arrow">
-    <a href="/pages/fun-projects.html">Fun Projects</a>
-  </li>
-  <li>
-    <img src="/assets/arrowright.gif" alt=">" class="arrow">
-    <a href="/pages/unfun-projects.html">Unfun Projects</a>
-  </li>
-  <li>
-    <img src="/assets/arrowright.gif" alt=">" class="arrow">
-    <a href="/pages/research.html">Research</a>
-  </li>
-  <li>
-    <img src="/assets/arrowright.gif" alt=">" class="arrow">
-    <a href="/pages/historia/index.html">Historia Dinosauralis</a></h
-  </li>
-  <li>
-    <img src="/assets/arrowright.gif" alt=">" class="arrow">
-    <a href="/pages/contact.html">Contact</a>
-  </li>
-  <li>
-    <img src="/assets/arrowright.gif" alt=">" class="arrow">
-    <a href="/CV.pdf">CV</a>
-  </li>
-
+  <li><a href="/pages/fun-projects.html">Fun Projects</a></li>
+  <li><a href="/pages/unfun-projects.html">Unfun Projects</a></li>
+  <li><a href="/pages/research.html">Research</a></li>
+  <li><a href="/pages/historia/index.html">Historia Dinosauralis</a></li>
+  <li><a href="/pages/contact.html">Contact</a></li>
+  <li><a href="/CV.pdf">CV</a></li>
 </ul>
 
   <div style="margin-bottom: 1em;">
-    <img src="/assets/elly.gif" alt="Elly is a good girl">
+    <img src="/assets/elly.gif" alt="Elly is a good girl" loading="lazy">
   </div>
 
 <style>
 .quick-links {
   list-style: none;
   padding: 0;
+  margin: 0;
 }
 .quick-links li {
-  display: flex;
-  align-items: center;
-  gap: 6px;
+  position: relative;
+  padding-left: 30px;
   margin: 6px 0;
 }
-.quick-links .arrow {
-  width: 24px;  /* small gif size */
-  height: auto;
+.quick-links li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 24px;
+  height: 24px;
+  background: url('/assets/arrowright.gif') no-repeat center/24px 24px;
 }
 </style>
 

--- a/js/historia.js
+++ b/js/historia.js
@@ -15,7 +15,7 @@ let _manifest;
  */
 async function loadManifest() {
   if (_manifest) return _manifest;
-  const r = await fetch(`/data/historia.index.json?v=${VERSION}`, { cache: "no-cache" });
+  const r = await fetch(`/data/historia.index.json?v=${VERSION}`, { cache: "force-cache" });
   if (!r.ok) throw new Error("Failed to load manifest");
   _manifest = await r.json();
   _manifest.entries = (_manifest.entries || []).filter(e => e && e.id && e.title);

--- a/js/site.js
+++ b/js/site.js
@@ -11,7 +11,7 @@ async function include(id, file) {
   // Attempt both relative and absolute paths so pages work from subdirectories.
   const tryFetch = async (url) => {
     try {
-      const r = await fetch(url, { cache: "no-cache" });
+      const r = await fetch(url);
       return r.ok ? await r.text() : null;
     } catch {
       return null;

--- a/partials/header.html
+++ b/partials/header.html
@@ -41,7 +41,7 @@
     display: inline-block;
     transform-origin: left center;
     font-size: 12px;
-    color: #000000:
+    color: #000000;
   }
 </style>
 


### PR DESCRIPTION
## Summary
- Streamline home page quick links with CSS arrow bullets and lazy-loading image
- Allow browser caching of shared partials and Historia manifest
- Fix header styling typo

## Testing
- `npx --yes htmlhint index.html partials/header.html` *(fails: 403 Forbidden)*
- `node --check js/site.js && echo 'site ok'`
- `node --check js/historia.js && echo 'historia ok'`


------
https://chatgpt.com/codex/tasks/task_e_68b0b0e665f08330a288c1f749ce2953