### PR TITLE
Add about section and playful UI effects

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,8 +18,10 @@
   <li><a href="/pages/research.html">Research</a></li>
   <li><a href="/pages/historia/index.html">Historia Dinosauralis</a></li>
   <li><a href="/pages/contact.html">Contact</a></li>
-  <li><a href="/CV.pdf">CV</a></li>
 </ul>
+
+<h3>About</h3>
+<p>I am an Electrical and Computer Engineering undergraduate student at Texas State University. I like building projects, robots, drones, dinosaurs, and anything soft and hardware related.</p>
 
   <div style="margin-bottom: 1em;">
     <img src="/assets/elly.gif" alt="Elly is a good girl" loading="lazy">

--- a/js/site.js
+++ b/js/site.js
@@ -73,6 +73,38 @@ function handleCitationBlock() {
   }
 }
 
+/**
+ * Spawn a colorful spark where the user clicks.
+ */
+function initClickEffect() {
+  const style = document.createElement("style");
+  style.textContent = `
+    .click-spark {
+      position: fixed;
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      pointer-events: none;
+      animation: spark-fade 600ms ease-out forwards;
+    }
+    @keyframes spark-fade {
+      from { transform: scale(1); opacity: 1; }
+      to { transform: scale(2); opacity: 0; }
+    }
+  `;
+  document.head.appendChild(style);
+
+  document.addEventListener("click", (e) => {
+    const s = document.createElement("span");
+    s.className = "click-spark";
+    s.style.left = e.clientX + "px";
+    s.style.top = e.clientY + "px";
+    s.style.background = `hsl(${Math.random() * 360}, 70%, 60%)`;
+    document.body.appendChild(s);
+    setTimeout(() => s.remove(), 600);
+  });
+}
+
 window.addEventListener("DOMContentLoaded", async () => {
   const tasks = [];
   if (document.getElementById("site-header")) tasks.push(include("site-header", "/partials/header.html"));
@@ -82,4 +114,5 @@ window.addEventListener("DOMContentLoaded", async () => {
   updateLastUpdated();
   updateShareLinks();
   handleCitationBlock();
+  initClickEffect();
 });

--- a/pages/contact.html
+++ b/pages/contact.html
@@ -17,14 +17,14 @@
     <img src="/assets/dino-mail.gif" alt="Dinosaur sending me an Email, like what you should do">
   </div>
 
-  <address id="contact-email">
-    <noscript>Email: contact [at] braedensilver [dot] com</noscript>
-  </address>
+  <p>Have feedback or just want to say hi? Reach out:</p>
 
-  <p>Elsewhere:
-    <a href="https://github.com/braedensilver">GitHub</a> ·
-    <a href="https://www.linkedin.com/in/braedensilver/">LinkedIn</a>
-  </p>
+  <ul class="contact-links">
+    <li><address id="contact-email"><noscript>Email: contact [at] braedensilver [dot] com</noscript></address></li>
+    <li><a href="https://www.linkedin.com/in/braedensilver/">LinkedIn</a></li>
+    <li><a href="https://github.com/braedensilver">GitHub</a></li>
+    <li><a href="/CV.pdf">CV</a></li>
+  </ul>
 </main>
 
 
@@ -39,5 +39,15 @@
     const slot = document.getElementById("contact-email"); if (slot) { slot.textContent = ""; slot.appendChild(a); }
   })();
 </script>
+
+<style>
+  .contact-links {
+    list-style: none;
+    padding: 0;
+  }
+  .contact-links li {
+    margin: 4px 0;
+  }
+</style>
 </body>
 </html>

--- a/partials/footer.html
+++ b/partials/footer.html
@@ -1,8 +1,8 @@
 <!-- Shared site footer with share links; loaded via js/site.js -->
 <footer>
+  <hr>
   <p>Last updated: <span id="last-updated"></span></p>
 
-<hr>
   <div id="share-block">
     <h3>Share this page</h3>
     <p>

--- a/partials/header.html
+++ b/partials/header.html
@@ -12,6 +12,10 @@
       </pre>
     </a>
   </h1>
+  <div class="googly-eyes">
+    <div class="eye"><div class="pupil"></div></div>
+    <div class="eye"><div class="pupil"></div></div>
+  </div>
 
   <nav>
     <a href="/index.html">Home</a> ·
@@ -19,8 +23,7 @@
     <a href="/pages/unfun-projects.html">Unfun Projects</a> ·
     <a href="/pages/research.html">Research</a> ·
     <a href="/pages/historia/index.html">Historia Dinosauralis</a> ·
-    <a href="/pages/contact.html">Contact</a> ·
-    <a href="/CV.pdf" target="_blank" rel="noopener noreferrer">CV</a>
+    <a href="/pages/contact.html">Contact</a>
   </nav>
 </header>
 <hr>
@@ -28,6 +31,7 @@
 <style>
   .ascii-header {
     text-align: left;
+    position: relative;
   }
   .ascii-logo-wrap {
     display: inline-block;
@@ -42,6 +46,33 @@
     transform-origin: left center;
     font-size: 12px;
     color: #000000;
+  }
+
+  .googly-eyes {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    display: flex;
+    gap: 6px;
+  }
+  .eye {
+    width: 20px;
+    height: 20px;
+    border: 2px solid #000;
+    border-radius: 50%;
+    background: #fff;
+    position: relative;
+    overflow: hidden;
+  }
+  .pupil {
+    width: 8px;
+    height: 8px;
+    background: #000;
+    border-radius: 50%;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
   }
 </style>
 
@@ -62,5 +93,22 @@
     addEventListener('load', fitAscii);
     addEventListener('resize', fitAscii);
     document.fonts && document.fonts.ready && document.fonts.ready.then(fitAscii);
+  })();
+
+  // Googly eyes follow cursor
+  (function () {
+    const pupils = document.querySelectorAll('.googly-eyes .pupil');
+    if (!pupils.length) return;
+    document.addEventListener('mousemove', (e) => {
+      pupils.forEach(pupil => {
+        const eye = pupil.parentElement;
+        const rect = eye.getBoundingClientRect();
+        const angle = Math.atan2(e.clientY - (rect.top + rect.height / 2), e.clientX - (rect.left + rect.width / 2));
+        const max = rect.width * 0.25;
+        const x = Math.cos(angle) * max;
+        const y = Math.sin(angle) * max;
+        pupil.style.transform = `translate(${x}px, ${y}px)`;
+      });
+    });
   })();
 </script>


### PR DESCRIPTION
## Summary
- Introduce an About blurb on the homepage describing EE/CE studies and hardware interests
- Expand the Contact page with feedback invite, email, LinkedIn, GitHub, and CV link
- Remove CV links from header and index, add googly eyes and click spark effects, and insert a footer divider above the last-updated field

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b82c364c8330b237d0faca6fa2cb