### PR TITLE
Remove googly eye code from header

### DIFF
--- a/partials/header.html
+++ b/partials/header.html
@@ -12,10 +12,6 @@
       </pre>
     </a>
   </h1>
-  <div class="googly-eyes">
-    <div class="eye"><div class="pupil"></div></div>
-    <div class="eye"><div class="pupil"></div></div>
-  </div>
 
   <nav>
     <a href="/index.html">Home</a> ·
@@ -48,32 +44,6 @@
     color: #000000;
   }
 
-  .googly-eyes {
-    position: absolute;
-    top: 10px;
-    right: 10px;
-    display: flex;
-    gap: 6px;
-  }
-  .eye {
-    width: 20px;
-    height: 20px;
-    border: 2px solid #000;
-    border-radius: 50%;
-    background: #fff;
-    position: relative;
-    overflow: hidden;
-  }
-  .pupil {
-    width: 8px;
-    height: 8px;
-    background: #000;
-    border-radius: 50%;
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-  }
 </style>
 
 <script>
@@ -93,22 +63,5 @@
     addEventListener('load', fitAscii);
     addEventListener('resize', fitAscii);
     document.fonts && document.fonts.ready && document.fonts.ready.then(fitAscii);
-  })();
-
-  // Googly eyes follow cursor
-  (function () {
-    const pupils = document.querySelectorAll('.googly-eyes .pupil');
-    if (!pupils.length) return;
-    document.addEventListener('mousemove', (e) => {
-      pupils.forEach(pupil => {
-        const eye = pupil.parentElement;
-        const rect = eye.getBoundingClientRect();
-        const angle = Math.atan2(e.clientY - (rect.top + rect.height / 2), e.clientX - (rect.left + rect.width / 2));
-        const max = rect.width * 0.25;
-        const x = Math.cos(angle) * max;
-        const y = Math.sin(angle) * max;
-        pupil.style.transform = `translate(${x}px, ${y}px)`;
-      });
-    });
   })();
 </script>


### PR DESCRIPTION
## Summary
- Remove googly eye markup from header
- Strip out related CSS styles and JavaScript cursor tracking

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c78b9b8c833081c7d24bc3c54e39