### PR TITLE
Add interactive googly eyes to footer

### DIFF
--- a/js/site.js
+++ b/js/site.js
@@ -115,4 +115,37 @@ window.addEventListener("DOMContentLoaded", async () => {
   updateShareLinks();
   handleCitationBlock();
   initClickEffect();
+
+  // Tiny googly eyes in footer
+  (() => {
+    const eyes = document.querySelectorAll('.footer-eyes .eye');
+    if (!eyes.length) return;
+
+    function movePupils(x, y) {
+      eyes.forEach(eye => {
+        const pupil = eye.querySelector('.pupil');
+        const rect = eye.getBoundingClientRect();
+        const cx = rect.left + rect.width / 2;
+        const cy = rect.top + rect.height / 2;
+        const dx = x - cx;
+        const dy = y - cy;
+        const radius = rect.width * 0.25;
+        const angle = Math.atan2(dy, dx);
+        const px = Math.cos(angle) * radius;
+        const py = Math.sin(angle) * radius;
+        pupil.style.transform = `translate(calc(-50% + ${px}px), calc(-50% + ${py}px))`;
+      });
+    }
+
+    function centerPupils() {
+      eyes.forEach(eye => {
+        const pupil = eye.querySelector('.pupil');
+        if (pupil) pupil.style.transform = 'translate(-50%, -50%)';
+      });
+    }
+
+    window.addEventListener('pointermove', e => movePupils(e.clientX, e.clientY));
+    window.addEventListener('mouseleave', centerPupils);
+    window.addEventListener('blur', centerPupils);
+  })();
 });

--- a/partials/footer.html
+++ b/partials/footer.html
@@ -25,4 +25,38 @@
     </blockquote>
     <small><em>Please don’t actually cite this in your research.</em></small>
   </div>
+
+  <div class="footer-eyes">
+    <div class="eye"><div class="pupil"></div></div>
+    <div class="eye"><div class="pupil"></div></div>
+  </div>
 </footer>
+
+<style>
+  .footer-eyes {
+    display: flex;
+    justify-content: center;
+    gap: 12px;
+    margin-top: 8px;
+  }
+  .footer-eyes .eye {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    background: #fff;
+    border: 2px solid #000;
+    position: relative;
+    overflow: hidden;
+  }
+  .footer-eyes .pupil {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: #000;
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    transition: transform 60ms linear;
+  }
+</style>


### PR DESCRIPTION
## Summary
- Add footer HTML for two tiny eyes and style them with simple CSS.
- Animate pupils with lightweight JS that tracks the cursor and recenters on blur or mouse leave.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0cb202d1c8330a203f2a7eb2d5332