### PR TITLE
Add animated Kilroy doodle to footer

### DIFF
--- a/js/site.js
+++ b/js/site.js
@@ -115,4 +115,37 @@ window.addEventListener("DOMContentLoaded", async () => {
   updateShareLinks();
   handleCitationBlock();
   initClickEffect();
+
+  // Kilroy googly eyes in footer
+  (() => {
+    const eyes = document.querySelectorAll('.kilroy .eye');
+    if (!eyes.length) return;
+
+    function movePupils(x, y) {
+      eyes.forEach(eye => {
+        const pupil = eye.querySelector('.pupil');
+        const rect = eye.getBoundingClientRect();
+        const cx = rect.left + rect.width / 2;
+        const cy = rect.top + rect.height / 2;
+        const dx = x - cx;
+        const dy = y - cy;
+        const radius = rect.width * 0.25;
+        const angle = Math.atan2(dy, dx);
+        const px = Math.cos(angle) * radius;
+        const py = Math.sin(angle) * radius;
+        pupil.style.transform = `translate(calc(-50% + ${px}px), calc(-50% + ${py}px))`;
+      });
+    }
+
+    function centerPupils() {
+      eyes.forEach(eye => {
+        const pupil = eye.querySelector('.pupil');
+        if (pupil) pupil.style.transform = 'translate(-50%, -50%)';
+      });
+    }
+
+    window.addEventListener('pointermove', e => movePupils(e.clientX, e.clientY));
+    window.addEventListener('mouseleave', centerPupils);
+    window.addEventListener('blur', centerPupils);
+  })();
 });

--- a/partials/footer.html
+++ b/partials/footer.html
@@ -25,4 +25,90 @@
     </blockquote>
     <small><em>Please don’t actually cite this in your research.</em></small>
   </div>
+
+  <div class="kilroy">
+    <div class="kilroy-head">
+      <div class="eye left"><div class="pupil"></div></div>
+      <div class="eye right"><div class="pupil"></div></div>
+      <div class="nose"></div>
+      <div class="hand left"><span></span><span></span><span></span></div>
+      <div class="hand right"><span></span><span></span><span></span></div>
+    </div>
+    <p class="kilroy-text">KILROY WAS HERE</p>
+  </div>
 </footer>
+
+<style>
+  .kilroy {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-top: 8px;
+  }
+  .kilroy-head {
+    position: relative;
+    width: 120px;
+    height: 60px;
+    border: 2px solid #000;
+    border-bottom: none;
+    border-top-left-radius: 60px 60px;
+    border-top-right-radius: 60px 60px;
+    background: #fff;
+  }
+  .kilroy .eye {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    background: #fff;
+    border: 2px solid #000;
+    position: absolute;
+    top: 20px;
+    overflow: hidden;
+  }
+  .kilroy .eye.left { left: 26px; }
+  .kilroy .eye.right { right: 26px; }
+  .kilroy .pupil {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: #000;
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    transition: transform 60ms linear;
+  }
+  .kilroy .nose {
+    position: absolute;
+    left: 50%;
+    bottom: -16px;
+    width: 32px;
+    height: 32px;
+    border: 2px solid #000;
+    border-radius: 50%;
+    background: #fff;
+    transform: translateX(-50%);
+  }
+  .kilroy .hand {
+    position: absolute;
+    bottom: -14px;
+    width: 32px;
+    display: flex;
+    justify-content: space-between;
+    padding: 0 4px;
+  }
+  .kilroy .hand span {
+    width: 4px;
+    height: 16px;
+    background: #000;
+    border-radius: 2px;
+  }
+  .kilroy .hand.left { left: -2px; }
+  .kilroy .hand.right { right: -2px; }
+  .kilroy-text {
+    margin-top: 20px;
+    font-family: monospace;
+    font-size: 12px;
+    letter-spacing: 1px;
+  }
+</style>


### PR DESCRIPTION
## Summary
- Replace simple footer eyes with a full "Kilroy was here" doodle including head, nose, and hands.
- Style Kilroy elements in black and white and add graffiti text below.
- Animate Kilroy's pupils to follow the cursor and reset when focus is lost.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0cb202d1c8330a203f2a7eb2d5332