### PR TITLE
Simplify footer Kilroy doodle

### DIFF
--- a/partials/footer.html
+++ b/partials/footer.html
@@ -1,19 +1,21 @@
 <!-- Shared site footer with share links; loaded via js/site.js -->
 <footer>
-  <hr>
-  <p>Last updated: <span id="last-updated"></span></p>
+  <div class="footer-info">
+    <hr>
+    <p>Last updated: <span id="last-updated"></span></p>
 
-  <div id="share-block">
-    <h3>Share this page</h3>
-    <p>
-      <a class="share-link twitter"   href="https://twitter.com/intent/tweet?text=Check+this+out&url=" target="_blank">Twitter/X</a> ·
-      <a class="share-link reddit"    href="https://www.reddit.com/submit?url=" target="_blank">Reddit</a> ·
-      <a class="share-link hn"        href="https://news.ycombinator.com/submitlink?u=" target="_blank">Hacker News</a> ·
-      <a class="share-link facebook"  href="https://www.facebook.com/sharer/sharer.php?u=" target="_blank">Facebook</a> ·
-      <a class="share-link linkedin"  href="https://www.linkedin.com/sharing/share-offsite/?url=" target="_blank">LinkedIn</a> ·
-      <a class="share-link whatsapp"  href="https://api.whatsapp.com/send?text=" target="_blank">WhatsApp</a> ·
-      <a class="share-link email"     href="mailto:?subject=Check this out&body=">Email</a>
-    </p>
+    <div id="share-block">
+      <h3>Share this page</h3>
+      <p>
+        <a class="share-link twitter"   href="https://twitter.com/intent/tweet?text=Check+this+out&url=" target="_blank">Twitter/X</a> ·
+        <a class="share-link reddit"    href="https://www.reddit.com/submit?url=" target="_blank">Reddit</a> ·
+        <a class="share-link hn"        href="https://news.ycombinator.com/submitlink?u=" target="_blank">Hacker News</a> ·
+        <a class="share-link facebook"  href="https://www.facebook.com/sharer/sharer.php?u=" target="_blank">Facebook</a> ·
+        <a class="share-link linkedin"  href="https://www.linkedin.com/sharing/share-offsite/?url=" target="_blank">LinkedIn</a> ·
+        <a class="share-link whatsapp"  href="https://api.whatsapp.com/send?text=" target="_blank">WhatsApp</a> ·
+        <a class="share-link email"     href="mailto:?subject=Check this out&body=">Email</a>
+      </p>
+    </div>
   </div>
 
 
@@ -32,29 +34,34 @@
         <div class="eye left"><div class="pupil"></div></div>
         <div class="eye right"><div class="pupil"></div></div>
       </div>
-      <div class="nose"></div>
-      <div class="hand left"><span></span><span></span><span></span></div>
-      <div class="hand right"><span></span><span></span><span></span></div>
     </div>
-    <p class="kilroy-text">KILROY WAS HERE</p>
   </div>
 </footer>
 
 <style>
   .kilroy {
-    margin-top: 24px;
     text-align: center;
   }
+  .footer-info {
+    position: fixed;
+    bottom: 80px;
+    left: 0;
+    right: 0;
+    text-align: center;
+    background: #fff;
+  }
   .kilroy-peek {
-    position: relative;
+    position: fixed;
+    bottom: 0;
+    left: 50%;
+    transform: translateX(-50%);
     width: 160px;
-    height: 40px;
-    margin: 0 auto;
+    height: 0;
     border-top: 2px solid #000;
   }
   .kilroy-peek .head {
     position: absolute;
-    top: -62px;
+    top: -56px;
     left: 50%;
     transform: translateX(-50%);
     width: 120px;
@@ -85,37 +92,5 @@
     top: 50%;
     transform: translate(-50%, -50%);
     transition: transform 60ms linear;
-  }
-  .kilroy-peek .nose {
-    width: 24px;
-    height: 24px;
-    border: 2px solid #000;
-    border-radius: 50%;
-    background: #fff;
-    position: absolute;
-    left: 50%;
-    top: -12px;
-    transform: translateX(-50%);
-  }
-  .kilroy-peek .hand {
-    position: absolute;
-    top: -14px;
-    display: flex;
-    gap: 3px;
-  }
-  .kilroy-peek .hand.left { left: 16px; }
-  .kilroy-peek .hand.right { right: 16px; }
-  .kilroy-peek .hand span {
-    width: 8px;
-    height: 14px;
-    border: 2px solid #000;
-    border-bottom: none;
-    border-radius: 8px 8px 0 0;
-    background: #fff;
-  }
-  .kilroy-text {
-    margin-top: 8px;
-    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
-    font-size: 16px;
   }
 </style>


### PR DESCRIPTION
## Summary
- Remove Kilroy nose, hands, and text so only his head with tracking eyes remains.
- Lower the Kilroy head and dividing line for a subtler peek.
- Pin the Kilroy doodle to the bottom of the viewport so it always peeks from the screen edge.
- Anchor “Last updated” and “Share this page” sections above the Kilroy doodle so they stick to the bottom of the screen.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d08185f08330a55b7f7373a0697a