### PR TITLE
Split footer content across bottom left and right

### DIFF
--- a/partials/footer.html
+++ b/partials/footer.html
@@ -1,12 +1,11 @@
 <!-- Shared site footer with share links; loaded via js/site.js -->
 <footer>
-  <div class="footer-info">
-    <hr>
-    <p>Last updated: <span id="last-updated"></span></p>
+  <div class="footer-bar">
+    <div class="footer-left">
+      <p class="last-updated">Last updated: <span id="last-updated"></span></p>
 
-    <div id="share-block">
-      <h3>Share this page</h3>
-      <p>
+      <div id="share-block">
+        <span>Share:</span>
         <a class="share-link twitter"   href="https://twitter.com/intent/tweet?text=Check+this+out&url=" target="_blank">Twitter/X</a> ·
         <a class="share-link reddit"    href="https://www.reddit.com/submit?url=" target="_blank">Reddit</a> ·
         <a class="share-link hn"        href="https://news.ycombinator.com/submitlink?u=" target="_blank">Hacker News</a> ·
@@ -14,10 +13,16 @@
         <a class="share-link linkedin"  href="https://www.linkedin.com/sharing/share-offsite/?url=" target="_blank">LinkedIn</a> ·
         <a class="share-link whatsapp"  href="https://api.whatsapp.com/send?text=" target="_blank">WhatsApp</a> ·
         <a class="share-link email"     href="mailto:?subject=Check this out&body=">Email</a>
-      </p>
+      </div>
+    </div>
+
+    <div class="kilroy-peek footer-eyes">
+      <div class="head">
+        <div class="eye left"><div class="pupil"></div></div>
+        <div class="eye right"><div class="pupil"></div></div>
+      </div>
     </div>
   </div>
-
 
   <!-- Historia-only citation block -->
   <div id="citation-block">
@@ -27,34 +32,41 @@
     </blockquote>
     <small><em>Please don’t actually cite this in your research.</em></small>
   </div>
-
-  <div class="kilroy">
-    <div class="kilroy-peek footer-eyes">
-      <div class="head">
-        <div class="eye left"><div class="pupil"></div></div>
-        <div class="eye right"><div class="pupil"></div></div>
-      </div>
-    </div>
-  </div>
 </footer>
 
 <style>
-  .kilroy {
-    text-align: center;
-  }
-  .footer-info {
-    position: fixed;
-    bottom: 80px;
-    left: 0;
-    right: 0;
-    text-align: center;
-    background: #fff;
-  }
-  .kilroy-peek {
+  .footer-bar {
     position: fixed;
     bottom: 0;
-    left: 50%;
-    transform: translateX(-50%);
+    left: 0;
+    right: 0;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    background: #fff;
+    padding: 0.5rem;
+  }
+  .footer-left {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+  .footer-left p,
+  .footer-left #share-block {
+    margin: 0;
+  }
+  #share-block {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+  }
+  #share-block span {
+    margin-right: 0.25rem;
+  }
+  .kilroy-peek {
+    position: relative;
     width: 160px;
     height: 0;
     border-top: 2px solid #000;
@@ -62,8 +74,7 @@
   .kilroy-peek .head {
     position: absolute;
     top: -56px;
-    left: 50%;
-    transform: translateX(-50%);
+    right: 0;
     width: 120px;
     height: 60px;
     border: 2px solid #000;


### PR DESCRIPTION
## Summary
- Group last-updated timestamp and share links on the footer's bottom-left
- Keep googly-eye graphic anchored at the bottom-right within the same footer bar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0db6cb46c833085acd06424d61494