### PR TITLE
feat: improve responsive layout

### DIFF
--- a/partials/footer.html
+++ b/partials/footer.html
@@ -44,6 +44,7 @@
     padding: 0.5rem;
     left: 0; /* full width */
     border-top: 2px solid #000; /* “wall” line */
+    flex-wrap: wrap;
   }
 
   .footer-bar p,
@@ -58,6 +59,17 @@
     gap: 0.25rem;
   }
   #share-block span { margin-right: 0.25rem; }
+
+  @media (max-width: 600px) {
+    .footer-bar {
+      flex-direction: column;
+      align-items: center;
+      text-align: center;
+    }
+    #share-block {
+      justify-content: center;
+    }
+  }
 
   /* Kilroy peeker on the right end of the bar */
   .kilroy-peek {

--- a/partials/header.html
+++ b/partials/header.html
@@ -25,15 +25,47 @@
 <hr>
 
 <style>
+  body {
+    padding-bottom: 140px;
+  }
+
+  main {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 0 1rem;
+  }
+
+  img,
+  video {
+    max-width: 100%;
+    height: auto;
+  }
+
+  pre {
+    overflow-x: auto;
+  }
+
   .ascii-header {
     text-align: left;
     position: relative;
   }
+
+  .ascii-header nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .ascii-header nav a {
+    white-space: nowrap;
+  }
+
   .ascii-logo-wrap {
     display: inline-block;
     max-width: min(95vw, 1100px);
     line-height: 1;
   }
+
   #ascii-logo {
     font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
     white-space: pre;


### PR DESCRIPTION
## Summary
- Add global responsive styles so images and main content scale on any device
- Allow header navigation to wrap on narrow screens
- Stack footer content on small viewports and prevent overlap with page text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e443733483309b2dc55467bad8cd