### PR TITLE
Make site responsive for mobile

### DIFF
--- a/404.html
+++ b/404.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>404 — Page Not Found</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="/css/style.css">
 </head>
 <body>
 <!-- Header and footer are injected by js/site.js -->

--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,19 @@
+/* Global responsive styles */
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+img, video, canvas, iframe {
+  max-width: 100%;
+  height: auto;
+}
+
+pre {
+  overflow-x: auto;
+}
+
+@media (max-width: 600px) {
+  body {
+    font-size: 16px;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta charset="utf-8">
   <title>Braeden Silver — Home</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="/css/style.css">
   <meta name="description" content="Braeden Silver — EE/CE student. Bio, projects, contact.">
 </head>
 <body>

--- a/pages/contact.html
+++ b/pages/contact.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>Contact — Braeden Silver</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="/css/style.css">
 </head>
 <body>
 

--- a/pages/fun-projects.html
+++ b/pages/fun-projects.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>Fun Projects — Braeden Silver</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="/css/style.css">
 </head>
 <body>
 
@@ -37,7 +38,7 @@
 }
 
 .project-entry .arrow {
-  width: 48px;
+  width: clamp(24px, 8vw, 48px);
   height: auto;
 }
 </style>

--- a/pages/historia/entry.html
+++ b/pages/historia/entry.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>Historia Entry</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="/css/style.css">
 </head>
 <body>
 <!-- Header and footer are injected by js/site.js -->

--- a/pages/historia/index.html
+++ b/pages/historia/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>Historia Dinosauralis — A–Z</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="/css/style.css">
 </head>
 <body>
 <!-- Header and footer are injected by js/site.js -->
@@ -13,7 +14,7 @@
   <h2>Historia Dinosauralis</h2>
   <p>A digital bestiary and encyclopedia. Click a letter to browse.</p>
 
-  <div style="margin-bottom: 1em;">
+  <div class="dino-gifs" style="margin-bottom: 1em;">
     <img src="/assets/Tyson.gif" alt="T-Rex gif">
     <img src="/assets/Rapty.gif" alt="Raptor gif">
     <img src="/assets/Sauromy.gif" alt="Sauropod gif">
@@ -26,7 +27,7 @@
   <div id="historia-az"><p>Loading…</p></div>
 </main>
 
-<div id="site-footer"></div>
+  <div id="site-footer"></div>
 
 <script src="/js/site.js" defer></script>
 <script type="module">
@@ -40,5 +41,15 @@
     document.getElementById("historia-az").textContent = "Failed to load entries.";
   });
 </script>
+<style>
+  .dino-gifs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+  .dino-gifs img {
+    flex: 1 1 80px;
+  }
+</style>
 </body>
 </html>

--- a/pages/historia/letter.html
+++ b/pages/historia/letter.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>Historia — Letter</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="/css/style.css">
 </head>
 <body>
 <!-- Header and footer are injected by js/site.js -->

--- a/pages/research.html
+++ b/pages/research.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>Research — Braeden Silver</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="/css/style.css">
 </head>
 <body>
 

--- a/pages/unfun-projects.html
+++ b/pages/unfun-projects.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>Unfun Projects — Braeden Silver</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="/css/style.css">
 </head>
 <body>
 
@@ -33,7 +34,7 @@
 }
 
 .project-entry .arrow {
-  width: 48px;
+  width: clamp(24px, 8vw, 48px);
   height: auto;
 }
 </style>

--- a/pages/unfun-projects/philosophy.html
+++ b/pages/unfun-projects/philosophy.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>Website Philosophy — Braeden Silver</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="/css/style.css">
 </head>
 <body>
 

--- a/partials/footer.html
+++ b/partials/footer.html
@@ -42,6 +42,7 @@
     display: flex;
     justify-content: space-between;  /* <-- pushes left group to left, Kilroy to right */
     align-items: flex-end;
+    flex-wrap: wrap;
     background: #fff;
     padding: 0.5rem 1rem;
     border-top: 2px solid #000;
@@ -109,5 +110,28 @@
 
   @media (prefers-reduced-motion: reduce) {
     .footer-eyes .pupil { transition: none; }
+  }
+
+  @media (max-width: 600px) {
+    .kilroy-peek {
+      width: 100px;
+    }
+    .kilroy-peek .head {
+      top: -40px;
+      width: 80px;
+      height: 40px;
+      border-radius: 40px 40px 0 0;
+    }
+    .footer-eyes .eye {
+      width: 18px;
+      height: 18px;
+      border-width: 1.5px;
+    }
+    .footer-eyes .eye.left  { left: 16px; top: 10px; }
+    .footer-eyes .eye.right { right: 16px; top: 10px; }
+    .footer-eyes .pupil {
+      width: 8px;
+      height: 8px;
+    }
   }
 </style>

--- a/partials/header.html
+++ b/partials/header.html
@@ -15,11 +15,11 @@
   </h1>
 
   <nav>
-    <a href="/index.html">Home</a> ·
-    <a href="/pages/fun-projects.html">Fun Projects</a> ·
-    <a href="/pages/unfun-projects.html">Unfun Projects</a> ·
-    <a href="/pages/research.html">Research</a> ·
-    <a href="/pages/historia/index.html">Historia Dinosauralis</a> ·
+    <a href="/index.html">Home</a>
+    <a href="/pages/fun-projects.html">Fun Projects</a>
+    <a href="/pages/unfun-projects.html">Unfun Projects</a>
+    <a href="/pages/research.html">Research</a>
+    <a href="/pages/historia/index.html">Historia Dinosauralis</a>
     <a href="/pages/contact.html">Contact</a>
   </nav>
 </header>
@@ -47,11 +47,22 @@
     white-space: pre;
     display: inline-block;
     transform-origin: left center;
-    font-size: 15px;
+    font-size: clamp(8px, 1.5vw, 15px);
     color: #000000;
   }
   .ascii-header nav {
     margin-top: 0.5rem;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.25rem;
+  }
+  .ascii-header nav a {
+    white-space: nowrap;
+  }
+  .ascii-header nav a:not(:first-child)::before {
+    content: "\00B7"; /* middle dot */
+    margin: 0 0.25rem 0 0;
   }
 
 </style>


### PR DESCRIPTION
## Summary
- add global stylesheet for responsive images and layout
- clamp ASCII logo and make navigation wrap cleanly
- shrink footer googly eyes on small screens and adjust arrow images

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0fb1f3cdc8330a562b64cbe33b5be