### PR TITLE
Improve page spacing and center main content

### DIFF
--- a/partials/footer.html
+++ b/partials/footer.html
@@ -34,7 +34,7 @@
 
 <style>
   body {
-    padding-bottom: 5rem;
+    padding-bottom: calc(5rem + 20px);
   }
   .footer-bar {
     position: fixed;

--- a/partials/header.html
+++ b/partials/header.html
@@ -28,6 +28,12 @@
 <style>
   body {
     margin: 0;
+    padding: 20px;
+    box-sizing: border-box;
+  }
+  main {
+    max-width: 800px;
+    margin: 0 auto;
   }
   .ascii-header {
     text-align: left;


### PR DESCRIPTION
## Summary
- Add global body padding and set main content to a centered max-width layout
- Increase bottom padding to accommodate fixed footer and prevent content overlap

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b101f81538833090b6cc231a1db1c9