### PR TITLE
feat: add mobile footer drawer

### DIFF
--- a/js/site.js
+++ b/js/site.js
@@ -105,6 +105,20 @@ function initClickEffect() {
   });
 }
 
+/**
+ * Toggle the footer drawer on mobile devices.
+ */
+function initFooterDrawer() {
+  const btn = document.getElementById("footer-toggle");
+  const drawer = document.getElementById("footer-drawer");
+  if (!btn || !drawer) return;
+  btn.addEventListener("click", () => {
+    const open = drawer.classList.toggle("open");
+    btn.setAttribute("aria-expanded", open);
+    btn.textContent = open ? "▼" : "▲";
+  });
+}
+
 
 window.addEventListener("DOMContentLoaded", async () => {
   const tasks = [];
@@ -116,6 +130,7 @@ window.addEventListener("DOMContentLoaded", async () => {
   updateShareLinks();
   handleCitationBlock();
   initClickEffect();
+  initFooterDrawer();
 
   // Tiny googly eyes in footer
   (() => {

--- a/partials/footer.html
+++ b/partials/footer.html
@@ -1,6 +1,7 @@
 <footer>
   <div class="footer-bar">
-    <div class="footer-left">
+    <button id="footer-toggle" aria-expanded="false">▲</button>
+    <div id="footer-drawer">
       <p class="last-updated">Last updated: <span id="last-updated"></span></p>
       <div id="share-block">
         <span>Share:</span>
@@ -40,22 +41,42 @@
     position: fixed;
     bottom: 0; left: 0; right: 0;
     display: flex;
-    justify-content: space-between;  /* <-- pushes left group to left, Kilroy to right */
+    justify-content: space-between;  /* <-- pushes content left, Kilroy to right */
     align-items: flex-end;
     background: #fff;
     padding: 0.5rem 1rem;
     border-top: 2px solid #000;
+    position: relative;
   }
 
-  .footer-left {
+  #footer-toggle {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 1.25rem;
+    line-height: 1;
+  }
+
+  #footer-drawer {
+    position: absolute;
+    bottom: 100%;
+    left: 0;
+    right: 0;
+    display: none;
+    flex-direction: column;
+    gap: 0.5rem;
+    background: #fff;
+    padding: 0.5rem 1rem;
+    border: 2px solid #000;
+    border-bottom: none;
+  }
+
+  #footer-drawer.open {
     display: flex;
-    align-items: center;
-    gap: 1rem;
-    flex-wrap: wrap;
   }
 
-  .footer-left p,
-  .footer-left #share-block {
+  #footer-drawer p,
+  #footer-drawer #share-block {
     margin: 0;
   }
 
@@ -66,6 +87,19 @@
     gap: 0.25rem;
   }
   #share-block span { margin-right: 0.25rem; }
+
+  @media (min-width: 600px) {
+    #footer-toggle { display: none; }
+    #footer-drawer {
+      position: static;
+      display: flex !important;
+      flex-direction: row;
+      align-items: center;
+      gap: 1rem;
+      border: none;
+      padding: 0;
+    }
+  }
 
   .kilroy-peek {
     position: relative;


### PR DESCRIPTION
## Summary
- add toggleable footer drawer for last updated and share links on mobile
- implement JS to open and close the drawer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b119aac5cc83308cbf457bd1636138