### PR TITLE
refactor: drop share links and footer drawer

### DIFF
--- a/js/site.js
+++ b/js/site.js
@@ -1,5 +1,5 @@
 // site.js — handles header/footer includes, "last updated" stamps,
-// social share links, and citation blocks for the Historia section.
+// citation blocks for the Historia section, and small UI effects.
 
 /**
  * Fetch an HTML partial and inject it into the element with the given ID.
@@ -8,19 +8,19 @@ async function include(id, file) {
   const el = document.getElementById(id);
   if (!el) return;
 
-  // Attempt both relative and absolute paths so pages work from subdirectories.
-  const tryFetch = async (url) => {
+  // Try both relative and absolute paths so pages work from subdirectories.
+  const candidates = [file, "/" + file.replace(/^\//, "")];
+  for (const url of candidates) {
     try {
       const r = await fetch(url);
-      return r.ok ? await r.text() : null;
+      if (r.ok) {
+        el.innerHTML = await r.text();
+        break;
+      }
     } catch {
-      return null;
+      /* ignore network errors and try next */
     }
-  };
-
-  let html = await tryFetch(file);
-  if (html == null) html = await tryFetch("/" + file.replace(/^\//, ""));
-  if (html != null) el.innerHTML = html;
+  }
 }
 
 /**
@@ -33,29 +33,6 @@ function updateLastUpdated() {
   t.textContent = new Date(document.lastModified).toLocaleDateString(undefined, opts);
 }
 
-/**
- * Fill social share links in the footer for the current page.
- */
-function updateShareLinks() {
-  const url = encodeURIComponent(window.location.href.split("#")[0]);
-  const title = encodeURIComponent(document.title);
-
-  const map = {
-    twitter:  (u, t) => `https://twitter.com/intent/tweet?text=${t}&url=${u}`,
-    reddit:   (u, t) => `https://www.reddit.com/submit?url=${u}&title=${t}`,
-    hn:       (u, t) => `https://news.ycombinator.com/submitlink?u=${u}&t=${t}`,
-    facebook: (u)    => `https://www.facebook.com/sharer/sharer.php?u=${u}`,
-    linkedin: (u)    => `https://www.linkedin.com/sharing/share-offsite/?url=${u}`,
-    whatsapp: (u, t) => `https://api.whatsapp.com/send?text=${t}%20${u}`,
-    email:    (u, t) => `mailto:?subject=${t}&body=${u}`
-  };
-
-  for (const [cls, build] of Object.entries(map)) {
-    document.querySelectorAll(`a.share-link.${cls}`).forEach(a => {
-      a.href = build(url, title);
-    });
-  }
-}
 
 /**
  * Ensure the citation block only appears on Historia pages.
@@ -105,19 +82,6 @@ function initClickEffect() {
   });
 }
 
-/**
- * Toggle the footer drawer on mobile devices.
- */
-function initFooterDrawer() {
-  const btn = document.getElementById("footer-toggle");
-  const drawer = document.getElementById("footer-drawer");
-  if (!btn || !drawer) return;
-  btn.addEventListener("click", () => {
-    const open = drawer.classList.toggle("open");
-    btn.setAttribute("aria-expanded", open);
-    btn.textContent = open ? "▼" : "▲";
-  });
-}
 
 
 window.addEventListener("DOMContentLoaded", async () => {
@@ -127,10 +91,8 @@ window.addEventListener("DOMContentLoaded", async () => {
   await Promise.all(tasks);
 
   updateLastUpdated();
-  updateShareLinks();
   handleCitationBlock();
   initClickEffect();
-  initFooterDrawer();
 
   // Tiny googly eyes in footer
   (() => {

--- a/partials/footer.html
+++ b/partials/footer.html
@@ -1,40 +1,6 @@
 <footer>
   <div class="footer-bar">
-    <!-- Left cluster: toggle + drawer (mobile), visible inline on desktop -->
-    <div class="footer-left">
-      <button id="footer-toggle" aria-expanded="false" aria-controls="footer-drawer" aria-label="Toggle footer">▲</button>
-      <div id="footer-drawer">
-        <p class="last-updated">Last updated: <span id="last-updated"></span></p>
-
-        <nav id="share-block" aria-label="Share this page">
-          <!-- NOTE:
-               Each <a> contains a .label for fallback text.
-               CSS hides .label *only if* icon backgrounds are supported.
-               If icons can't load, the label text remains visible. -->
-          <a class="share-link x"         href="https://twitter.com/intent/tweet?text=Check+this+out&url="  target="_blank" rel="noopener" aria-label="Share on X">
-            <span class="label">X</span>
-          </a>
-          <a class="share-link reddit"    href="https://www.reddit.com/submit?url="                         target="_blank" rel="noopener" aria-label="Share on Reddit">
-            <span class="label">Reddit</span>
-          </a>
-          <a class="share-link hn"        href="https://news.ycombinator.com/submitlink?u="                 target="_blank" rel="noopener" aria-label="Share on Hacker News">
-            <span class="label">HN</span>
-          </a>
-          <a class="share-link facebook"  href="https://www.facebook.com/sharer/sharer.php?u="              target="_blank" rel="noopener" aria-label="Share on Facebook">
-            <span class="label">Facebook</span>
-          </a>
-          <a class="share-link linkedin"  href="https://www.linkedin.com/sharing/share-offsite/?url="       target="_blank" rel="noopener" aria-label="Share on LinkedIn">
-            <span class="label">LinkedIn</span>
-          </a>
-          <a class="share-link whatsapp"  href="https://api.whatsapp.com/send?text="                        target="_blank" rel="noopener" aria-label="Share on WhatsApp">
-            <span class="label">WhatsApp</span>
-          </a>
-          <a class="share-link email"     href="mailto:?subject=Check this out&body="                       aria-label="Share via Email">
-            <span class="label">Email</span>
-          </a>
-        </nav>
-      </div>
-    </div>
+    <p class="last-updated">Last updated: <span id="last-updated"></span></p>
 
     <!-- Right cluster: Kilroy -->
     <div class="kilroy-peek footer-eyes" aria-hidden="true">
@@ -70,86 +36,7 @@
     border-top: 2px solid #000;
   }
 
-  /* Left group */
-  .footer-left { display: flex; align-items: center; gap: 0.5rem; }
-
-  #footer-toggle {
-    background: none; border: none; cursor: pointer;
-    font-size: 1.1rem; line-height: 1; padding: 0.25rem 0.35rem;
-  }
-
-  #footer-drawer {
-    position: absolute;
-    bottom: 100%;
-    left: 0; right: 0;
-    display: none; /* mobile collapsed by default */
-    flex-direction: column; gap: 0.5rem;
-    background: #fff; padding: 0.6rem 1rem;
-    border: 2px solid #000; border-bottom: none;
-  }
-  #footer-drawer.open { display: flex; }
-
-  #footer-drawer p { margin: 0; }
-
-  #share-block {
-    display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap;
-  }
-
-  /* Icon buttons: default show label (text fallback).
-     If the browser supports background images, we hide the label and draw a circular icon. */
-  .share-link {
-    display: inline-flex; align-items: center; justify-content: center;
-    min-width: 28px; height: 28px; padding: 0 8px;
-    border-radius: 999px; text-decoration: none; font-weight: 600;
-    border: 2px solid #0000; /* solid only on hover focus for a11y */
-    transition: transform 120ms ease;
-  }
-  .share-link:focus-visible { outline: none; border-color: #000; }
-  .share-link:hover { transform: translateY(-1px); }
-
-  /* Brand colors (background for the icon case; pill bg for text fallback) */
-  .share-link.x         { background: #000; color: #fff; }
-  .share-link.reddit    { background: #FF4500; color: #fff; }
-  .share-link.hn        { background: #FF6600; color: #fff; }
-  .share-link.facebook  { background: #1877F2; color: #fff; }
-  .share-link.linkedin  { background: #0A66C2; color: #fff; }
-  .share-link.whatsapp  { background: #25D366; color: #fff; }
-  .share-link.email     { background: #555;    color: #fff; }
-
-  /* Upgrade to round icon-only if CSS background works.
-     We use :before with a data-URI SVG; .label is visually hidden in this mode only. */
-  @supports (background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E")) {
-    .share-link {
-      width: 28px; padding: 0; border-radius: 50%;
-    }
-    .share-link .label {
-      position: absolute !important; width: 1px; height: 1px;
-      margin: -1px; padding: 0; border: 0; overflow: hidden;
-      clip: rect(0 0 0 0); white-space: nowrap;
-    }
-    .share-link::before {
-      content: ""; width: 60%; height: 60%;
-      background-repeat: no-repeat; background-position: center; background-size: contain;
-      filter: invert(100%); /* white glyphs */
-    }
-    .share-link.x::before        { background-image: url("data:image/svg+xml;utf8,<svg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'><path fill='%23fff' d='M18.9 3H21l-6.56 7.49L22 21h-6.1l-4.77-5.74L5.6 21H3l6.99-7.98L2 3h6.2l4.3 5.17L18.9 3Zm-2.15 16.01h1.13L7.31 4.06H6.1l10.65 14.95Z'/></svg>"); }
-    .share-link.reddit::before   { background-image: url("data:image/svg+xml;utf8,<svg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'><path fill='%23fff' d='M21 10.5a2 2 0 0 0-3.4-1.4 7 7 0 0 0-3.91-1.24l.68-3.2 2.23.47a1.5 1.5 0 1 0 .24-1.18l-2.86-.6a.75.75 0 0 0-.87.57l-.86 4.04a7.1 7.1 0 0 0-4.41 1.24A2 2 0 1 0 3 10.5c0 .7.36 1.32.92 1.68a4.9 4.9 0 0 0-.07.82c0 2.96 3.58 5.35 8 5.35s8-2.39 8-5.35c0-.28-.03-.55-.07-.82.56-.36.92-.97.92-1.68ZM9 12.25a1.25 1.25 0 1 1 0 2.5 1.25 1.25 0 0 1 0-2.5Zm6.5 3.96c-.96.65-2.43 1.06-4 1.06s-3.04-.41-4-1.06a.5.5 0 1 1 .57-.82c.73.49 1.99.88 3.43.88s2.7-.39 3.43-.88a.5.5 0 1 1 .57.82ZM15 12.25a1.25 1.25 0 1 1 0 2.5 1.25 1.25 0 0 1 0-2.5Z'/></svg>"); }
-    .share-link.hn::before       { background-image: url("data:image/svg+xml;utf8,<svg viewBox='0 0 64 64' xmlns='http://www.w3.org/2000/svg'><path fill='%23fff' d='M28 16v2l6 12 6-12v-2h4v2L36 36v12h-4V36L24 18v-2z'/></svg>"); }
-    .share-link.facebook::before { background-image: url("data:image/svg+xml;utf8,<svg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'><path fill='%23fff' d='M13.5 9H16V6h-2.5C11.6 6 11 7.1 11 8.5V10H9v3h2v7h3v-7h2.1l.4-3H14v-1c0-.6.2-1 .5-1z'/></svg>"); }
-    .share-link.linkedin::before { background-image: url("data:image/svg+xml;utf8,<svg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'><path fill='%23fff' d='M6.94 7.5a1.94 1.94 0 1 1 0-3.88 1.94 1.94 0 0 1 0 3.88zM5 9h3.9v12H5zM14.74 9c-2.2 0-3.2 1.2-3.75 2V9H7.1v12h3.9v-6.7c0-1.78 1.22-2.15 1.68-2.15s1.62.37 1.62 2.15V21h3.9v-7.3C18.2 10.6 16.93 9 14.74 9z'/></svg>"); }
-    .share-link.whatsapp::before { background-image: url("data:image/svg+xml;utf8,<svg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'><path fill='%23fff' d='M12 2a9.8 9.8 0 0 0-8.58 14.63L2 22l5.5-1.4A9.8 9.8 0 1 0 12 2Zm5.68 14.06c-.23.64-1.33 1.22-1.84 1.3-.47.08-1.08.11-1.74-.11-.4-.13-.9-.29-1.55-.58-2.73-1.18-4.5-3.93-4.64-4.12-.13-.19-1.11-1.47-1.11-2.8 0-1.34.7-1.98.95-2.26.26-.28.57-.35.76-.35h.55c.18 0 .41.06.63.48.24.47.83 1.63.91 1.75.07.12.12.27.02.44-.09.19-.14.27-.26.42-.13.15-.27.33-.38.45-.12.12-.24.26-.1.5.13.24.6.98 1.28 1.6.88.79 1.62 1.04 1.87 1.16.24.12.39.1.54-.06.15-.16.63-.73.8-.98.17-.24.34-.2.57-.12.23.08 1.45.68 1.7.8.25.11.41.18.47.28.06.1.06.58-.17 1.22Z'/></svg>"); }
-    .share-link.email::before    { background-image: url("data:image/svg+xml;utf8,<svg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'><path fill='%23fff' d='M20 4H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2Zm0 3.2-8 5.3L4 7.2V6l8 5.3L20 6v1.2Z'/></svg>"); }
-  }
-
-  /* Desktop: inline (no drawer), better spacing; keep Kilroy right-aligned */
-  @media (min-width: 700px) {
-    #footer-toggle { display: none; }
-    #footer-drawer {
-      position: static; display: flex !important;
-      flex-direction: row; align-items: center; gap: 1rem;
-      border: none; padding: 0; box-shadow: none;
-    }
-  }
+  .last-updated { margin: 0; }
 
   /* Kilroy (full circle) */
   .kilroy-peek {


### PR DESCRIPTION
## Summary
- remove social share script and footer drawer toggle
- simplify footer to only show last updated and Kilroy peeking eyes

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a15e007c83308b9153e218ad906c