### PR TITLE
Fix custom cursor fallback on homepage and shrink size

### DIFF
--- a/js/site.js
+++ b/js/site.js
@@ -97,6 +97,44 @@ function initClickEffect() {
   });
 }
 
+/**
+ * Hide the native cursor and replace it with a smaller custom one.
+ */
+function initCustomCursor() {
+  const style = document.createElement("style");
+  style.textContent = `
+    html, body, a, button { cursor: none; }
+    #custom-cursor {
+      position: fixed;
+      left: 0;
+      top: 0;
+      width: 24px;
+      height: 24px;
+      pointer-events: none;
+      background: url('/assets/cursor/default.png') no-repeat center/24px 24px;
+      z-index: 10000;
+    }
+    #custom-cursor.pointer {
+      background-image: url('/assets/cursor/pointer.png');
+    }
+  `;
+  document.head.appendChild(style);
+
+  const cursor = document.createElement('div');
+  cursor.id = 'custom-cursor';
+  document.body.appendChild(cursor);
+
+  document.addEventListener('pointermove', e => {
+    cursor.style.left = (e.clientX - 3) + 'px';
+    cursor.style.top = (e.clientY - 3) + 'px';
+    if (e.target.closest('a, button')) {
+      cursor.classList.add('pointer');
+    } else {
+      cursor.classList.remove('pointer');
+    }
+  });
+}
+
 
 
 window.addEventListener("DOMContentLoaded", async () => {
@@ -108,6 +146,7 @@ window.addEventListener("DOMContentLoaded", async () => {
   await updateLastUpdated();
   handleCitationBlock();
   initClickEffect();
+  initCustomCursor();
 
   // Tiny googly eyes in footer
   (() => {

--- a/partials/header.html
+++ b/partials/header.html
@@ -29,10 +29,6 @@
     margin: 0;
     padding: 20px;
     box-sizing: border-box;
-    cursor: url('/assets/cursor/default.png') 4 4, auto;
-  }
-  a, button {
-    cursor: url('/assets/cursor/pointer.png') 4 4, pointer;
   }
   main {
     max-width: 800px;


### PR DESCRIPTION
## Summary
- Replace CSS cursor with JS-driven element so the cursor stays custom across the page
- Scale the cursor graphics down to ~24px (~75% of original size)
- Clean up old cursor declarations from header partial

## Testing
- `node --check js/site.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf815b3cec8330b19657d1fb8aac64