### PR TITLE
Simplify project documentation tone

### DIFF
--- a/BRAND_GUIDE.md
+++ b/BRAND_GUIDE.md
@@ -1,15 +1,15 @@
-# Brand & Attribution Guardrails
+# Brand & Attribution Guidelines
 
-These rules protect the identity of Braeden Silver while still letting you remix the work.
+These guidelines explain how to reference Braeden Silver and the braedensilver.com project when reusing code or content from this repository.
 
-## Be Honest About Origin
-- Do not claim or imply that your derivative is the official braedensilver.com site.
-- Do not use Braeden Silver’s name, likeness, or personal contact details in ways that could confuse people about who created or operates your derivative.
+## Attribution
+- Clearly state that your work is based on material from braedensilver.com.
+- Distinguish your derivative project from the original site so visitors understand who maintains each version.
 
-## Attribution Choices
-- Code and content released under CC BY 4.0 require attribution that clearly distinguishes your work from the original.
+## Use of Name and Likeness
+- Do not imply endorsement or authorship by Braeden Silver unless you have written permission.
+- Avoid reusing personal imagery or signatures without approval.
 
 ## Visual Identity
-- Feel free to remix colors, layouts, and imagery, but avoid copying personal photography or signatures unless you have explicit permission.
-
-When in doubt, reach out via an issue or the contact links on the live site before shipping.
+- You are encouraged to adapt colors, layouts, or typography to suit your project.
+- When in doubt about specific assets, contact the maintainer through the repository issue tracker.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,34 +1,27 @@
 # Contributing to BraedenSilver.github.io
 
-First off, thank you for wanting to enhance the site. The goal is to keep the vibe fierce, honest, and fast. Follow these guidelines so we can ship with confidence.
+Thank you for your interest in improving this site. The goal is to keep the content accurate and the codebase easy to maintain. Please follow the guidelines below when proposing changes.
 
-## 🔧 Ground Rules
-- Be respectful and keep feedback constructive.
-- Do not copy/paste content from the site elsewhere without respecting the [Anonymized Remix License](LICENSE).
-- Never misrepresent yourself as Braeden Silver or claim ownership of their identity.
+## Expectations
+- Maintain a respectful and professional tone in issues and pull requests.
+- Follow the licensing terms in [`LICENSE`](LICENSE) when reusing content.
+- Do not represent yourself as Braeden Silver or imply endorsement.
 
-## 🛠 Development Workflow
-1. **Fork** the repo and create your feature branch from `main`.
-2. **Install** dependencies if you need build tooling. This site is static, so a local server (Python, Node `serve`, etc.) is usually enough.
-3. **Build & test** your changes locally. Run through the affected pages to ensure there are no regressions.
-4. **Commit** using clear messages that explain the why, not just the what.
-5. **Open a pull request** using the provided template. Link any relevant issues.
+## Development Workflow
+1. **Fork the repository** and create a feature branch from `main`.
+2. **Develop locally** using any static file server (for example, `python3 -m http.server 8000`).
+3. **Test your changes** by reviewing the affected pages in a browser.
+4. **Commit clearly** with messages that describe the motivation for the change.
+5. **Open a pull request** using the provided template and link to related issues when applicable.
 
-## ✅ Content & Code Standards
-- Keep HTML semantic, CSS organized, and JavaScript lean.
-- Match existing formatting and naming conventions within folders.
-- For blog entries, use the JSON structure documented in the [README](README.md).
-- Include screenshots or GIFs for visual changes when possible.
+## Code and Content Standards
+- Use semantic HTML, organized CSS, and concise JavaScript.
+- Match existing formatting and file organization within each directory.
+- For blog updates, follow the JSON structure described in the [README](README.md).
+- Include screenshots or other documentation for visual changes when possible.
 
-## 🧾 Pull Requests
-Every PR should:
-- Have a descriptive title.
-- Explain the motivation, the changes made, and any follow-up work.
-- Reference related issues using GitHub keywords (`Closes #123`).
-- Pass any checks or linters you introduce.
+## Issues
+- Use the templates in [`.github/ISSUE_TEMPLATE`](.github/ISSUE_TEMPLATE) for bug reports or feature requests.
+- Provide reproduction steps, expected behavior, and any relevant screenshots.
 
-## 🗳 Issues
-- Use the templates in [`.github/ISSUE_TEMPLATE`](.github/ISSUE_TEMPLATE) when filing bugs or feature requests.
-- Provide reproduction steps, screenshots, and expected vs actual behavior.
-
-Thanks for keeping the forge burning hot! 🔥
+We appreciate your contributions and collaboration.

--- a/README.md
+++ b/README.md
@@ -1,58 +1,37 @@
-# ⚔️ Braeden Silver: Digital Forge
+# Braeden Silver Personal Site
 
-Welcome to the codebase that powers [braedensilver.com](https://braedensilver.com) — a handcrafted personal site forged from static assets, sharp design, and unapologetic vibes. This repo is my war chest of pages, components, and data that back the entire experience.
+This repository contains the source files for [braedensilver.com](https://braedensilver.com), a static site built with HTML, CSS, and JavaScript. The project is organized for clarity and easy maintenance, whether you are reviewing the codebase or preparing small updates.
 
-[![GitHub Pages](https://img.shields.io/badge/hosted%20on-GitHub%20Pages-111?logo=github)](https://braedensilver.github.io/)
-[![Last Commit](https://img.shields.io/github/last-commit/BraedenSilver/BraedenSilver.github.io?color=ff4d5a)](https://github.com/BraedenSilver/BraedenSilver.github.io/commits/main)
-[![Made with HTML5](https://img.shields.io/badge/made%20with-HTML5-e96228?logo=html5&logoColor=white)](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/HTML5)
-
-## 🔮 What Lives Here
-- **Static pages** crafted in pure HTML, CSS, and JavaScript with zero frameworks slowing things down.
-- **Partial templates** that keep layout and components DRY.
-- **JSON-driven content** for the blog and portfolio entries, so updating stories never touches markup.
-- **Assets** (fonts, imagery, icons) that keep the aesthetic loud and clear.
-
-If you're here to remix or learn from the setup, you’re in the right forge. Just remember: respect the identity, remix the ideas.
-
-## 🧠 Architecture Snapshot
-| Layer | Purpose |
+## Repository Structure
+| Directory | Purpose |
 | --- | --- |
 | `index.html` | Landing page and primary entry point. |
-| `pages/` | Long-form subpages (résumé, blog index, detailed writeups). |
-| `partials/` | Shared header/footer components injected at build/runtime. |
-| `data/` | JSON manifests for blog posts, projects, and other structured content. |
-| `assets/` & `js/` | Styling, icons, and behavior that pull everything together. |
+| `pages/` | Long-form subpages such as the résumé and blog index. |
+| `partials/` | Shared layout components including the header and footer. |
+| `data/` | JSON data for blog posts, portfolio entries, and other structured content. |
+| `assets/`, `js/` | Styling, icons, and scripts used throughout the site. |
 
-## 📝 Publishing a Blog Entry Like a Pro
-1. **Register the post** in [`data/blog.index.json`](data/blog.index.json) by adding a new object to `entries`. Provide:
-   - `id`: slugified identifier (`2024-10-08-daily-notes`).
-   - `title`, `date`, `summary`: metadata for listings.
-   - Optional `tags`, `reading_time`, or anything else the frontend expects.
-2. **Create the content file** in [`data/blog/`](data/blog). Name it `<id>.json` and echo the metadata plus a `body` string with paragraphs separated by blank lines. Drop optional `links` callouts at the end if you need CTAs.
-3. **Ship it.** Commit both files and push — the static site generator makes the new story available at `/pages/blog/post.html?id=<id>` automatically.
+## Updating Blog Content
+1. Add a new entry to [`data/blog.index.json`](data/blog.index.json) with the post metadata (`id`, `title`, `date`, `summary`, and optional fields such as `tags`).
+2. Create a corresponding JSON file in [`data/blog/`](data/blog) named `<id>.json`. Include the same metadata plus a `body` field containing the article content.
+3. Commit both files together and deploy. The new article becomes available at `/pages/blog/post.html?id=<id>`.
 
-## 🚀 Local Development
+## Local Development
+The site is fully static, so any simple web server will work:
+
 ```bash
-# clone the beast
- git clone https://github.com/BraedenSilver/BraedenSilver.github.io.git
- cd BraedenSilver.github.io
-
-# serve the static files however you like
- python3 -m http.server 8000
-# or
- npx serve
+git clone https://github.com/BraedenSilver/BraedenSilver.github.io.git
+cd BraedenSilver.github.io
+python3 -m http.server 8000  # or use npx serve
 ```
-Visit `http://localhost:8000` (or whatever port you pick) and iterate.
 
-## 🤝 Contributing
-Pull requests are welcome! Check out [`CONTRIBUTING.md`](CONTRIBUTING.md) for branching, coding, and content guidelines before you submit. Templates for issues and PRs live under [`.github/`](.github/).
+Open `http://localhost:8000` in a browser to preview changes.
 
-## 🛡 License & Usage Code
-- **Site code** (HTML, CSS, JavaScript, build scripts) and **site content** (copy, blog posts, media assets) are both released under [Creative Commons Attribution 4.0 International](LICENSE). Remix anything you find here, just credit the original work.
+## Contributing
+Pull requests are welcome. Please review [`CONTRIBUTING.md`](CONTRIBUTING.md) for expectations around code style, documentation, and review.
 
-Need guidance on how to credit or what’s off limits? Check the [Brand & Attribution Guardrails](BRAND_GUIDE.md) before you publish derivatives.
+## License
+The site code and published content are available under the [Creative Commons Attribution 4.0 International License](LICENSE). Please provide clear attribution when reusing or adapting this material.
 
-## 💬 Contact
-Wanna talk shop, collaborate, or compare battle scars? Reach me via the links on the live site or drop an issue in this repo.
-
-Stay sharp. Build bold.
+## Contact
+For questions or collaboration requests, open an issue in this repository or use the contact details listed on the live site.


### PR DESCRIPTION
## Summary
- rewrite the README with a concise description of the site, repository structure, and workflows
- update the brand guidelines to clarify attribution and identity usage in a professional tone
- refresh the contributing guide with straightforward expectations and workflow steps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dff18356388330a185c25cb6a75185