### PR TITLE
Align tag filters and Konami overlay

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -628,7 +628,7 @@ body.konami-active {
   height: 24px;
   pointer-events: none;
   background: url('/assets/cursor/default.png') no-repeat center/24px 24px;
-  z-index: 10000;
+  z-index: 12000;
 }
 
 .cursor-enabled #custom-cursor.pointer {
@@ -645,13 +645,18 @@ details#sources[open] > ol {
   max-height: 2000px;
 }
 
+.page-intro,
 .blog-intro {
   font-size: 1.1rem;
   line-height: 1.6;
 }
 
-.blog-controls {
+.blog-controls,
+.project-controls {
   margin-top: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 .blog-filter {

--- a/js/site.js
+++ b/js/site.js
@@ -200,7 +200,6 @@ function initKonamiCode() {
     overlay.setAttribute('role', 'dialog');
     overlay.setAttribute('aria-modal', 'true');
     overlay.setAttribute('aria-labelledby', 'konami-title');
-    overlay.setAttribute('aria-describedby', 'konami-description konami-subtext');
 
     const panel = document.createElement('div');
     panel.className = 'konami-panel';
@@ -208,11 +207,7 @@ function initKonamiCode() {
 
     const title = document.createElement('h2');
     title.id = 'konami-title';
-    title.textContent = 'You unlocked a live Talking Heads moment!';
-
-    const message = document.createElement('p');
-    message.id = 'konami-description';
-    message.textContent = 'Enjoy “Once in a Lifetime” by Talking Heads. Volume up, existential dancing optional.';
+    title.textContent = 'Secret Video Unlocked';
 
     const videoWrap = document.createElement('div');
     videoWrap.className = 'konami-video';
@@ -226,20 +221,14 @@ function initKonamiCode() {
     video.referrerPolicy = 'strict-origin-when-cross-origin';
     videoWrap.appendChild(video);
 
-    const subtext = document.createElement('p');
-    subtext.id = 'konami-subtext';
-    subtext.textContent = 'Press escape or click outside the video to close the concert and get back to work.';
-
     const close = document.createElement('button');
     close.type = 'button';
     close.className = 'konami-close';
-    close.textContent = 'Close the show';
+    close.textContent = 'Exit video';
     close.addEventListener('click', removeOverlay);
 
     panel.appendChild(title);
-    panel.appendChild(message);
     panel.appendChild(videoWrap);
-    panel.appendChild(subtext);
     panel.appendChild(close);
 
     overlay.appendChild(panel);

--- a/pages/blog/index.html
+++ b/pages/blog/index.html
@@ -73,7 +73,7 @@
     </a>
   </nav>
     <h1>Blog</h1>
-    <p class="blog-intro">I post quick write-ups when a project teaches me something worth remembering. Expect notes on firmware, lab gear, and whatever mechanical contraptions are cluttering my desk.</p>
+    <p class="page-intro">I post quick write-ups when a project teaches me something worth remembering. Expect notes on firmware, lab gear, and whatever mechanical contraptions are cluttering my desk.</p>
     <section class="blog-controls" aria-label="Filter blog posts">
       <div class="blog-filter" id="blog-filter" hidden>
         <h2 class="blog-filter-title">Find posts by tag</h2>

--- a/pages/projects.html
+++ b/pages/projects.html
@@ -76,7 +76,7 @@
     </a>
   </nav>
   <h1>Projects</h1>
-  <p>Personal builds I do for fun or obligation. Use the tags to filter the vibe.</p>
+  <p class="page-intro">Personal builds I do for fun or obligation. Use the tags to filter the vibe.</p>
   <section class="project-controls" aria-label="Filter projects">
     <div class="blog-filter" id="project-filter" hidden>
       <h2 class="blog-filter-title">Find projects by tag</h2>


### PR DESCRIPTION
## Summary
- share intro and control styling so the blog and projects tag filters line up
- raise the custom cursor z-index so it remains visible over the Konami overlay
- simplify the Konami Easter egg copy to "Secret Video Unlocked" with an "Exit video" button

## Testing
- Manual verification

------
https://chatgpt.com/codex/tasks/task_e_68e02ec399bc83309a2e2e962d3f9157