### PR TITLE
Match project tag spacing with blogs and update Konami video start time

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -287,7 +287,7 @@ main {
 .project-entry-content {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0;
   flex: 1;
 }
 
@@ -296,8 +296,8 @@ main {
   line-height: 1.5;
 }
 
-.project-tags {
-  margin: 0;
+.project-entry-content > .project-tags:not(:first-child) {
+  margin-top: 0.75rem;
 }
 
 :is(.project-entry, .quick-link) .arrow {

--- a/js/site.js
+++ b/js/site.js
@@ -213,7 +213,7 @@ function initKonamiCode() {
     videoWrap.className = 'konami-video';
 
     const video = document.createElement('iframe');
-    video.src = 'https://www.youtube.com/embed/5IsSpAOD6K8?autoplay=1';
+    video.src = 'https://www.youtube.com/embed/5IsSpAOD6K8?autoplay=1&start=12';
     video.title = 'Talking Heads — Once in a Lifetime';
     video.allow = 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share';
     video.allowFullscreen = true;


### PR DESCRIPTION
## Summary
- adjust project entries so their tag lists sit 0.75rem below preceding content, mirroring blog spacing
- make the hidden Konami video begin playback 12 seconds into the track

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e035c5ec1c8330a273b26d642cdb2f