### PR TITLE
Increase mobile scroll space below fixed footer

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -12,7 +12,13 @@ body {
   font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   background: #fff;
   color: #000;
-  padding-bottom: calc(5rem + 24px);
+  /*
+   * Reserve generous space for the fixed footer so page content (like the
+   * Elly gif and quick links) can scroll fully into view on small screens.
+   * The max() keeps the previous desktop spacing while guaranteeing extra
+   * room on shorter viewports.
+   */
+  padding-bottom: max(calc(5rem + 24px), 40vh);
 }
 
 :where(a, button, [role="button"]):focus-visible {
@@ -36,6 +42,7 @@ body {
 @media (max-width: 600px) {
   body {
     padding: 10px;
+    padding-bottom: max(calc(5rem + 24px), 40vh);
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure page body reserves more space beneath the fixed footer so content can scroll fully into view
- keep compact side padding on small screens while preserving the larger bottom offset
- document the new spacing approach directly in the stylesheet

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e079c0b1f483308e5dcecb967bf5eb