### PR TITLE
Reposition guestbook instructions panel

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -1195,20 +1195,79 @@ details#sources[open] > ol {
   max-width: 60ch;
 }
 
-.guestbook-how-to {
-  margin-top: 2rem;
-  padding: 1.5rem;
+.guestbook-layout {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  margin-top: 1rem;
+}
+
+.guestbook-instructions {
   border: 2px solid var(--color-border);
   border-radius: 0.75rem;
   background: var(--color-panel-muted);
+  padding: 1.25rem;
 }
 
-.guestbook-how-to ol {
+.guestbook-instructions__header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.guestbook-instructions__title {
+  margin: 0;
+}
+
+.guestbook-instructions__toggle {
+  display: none;
+  margin-left: auto;
+  padding: 0.5rem 0.9rem;
+  border-radius: 999px;
+  border: 2px solid var(--color-border);
+  background: var(--color-bg);
+  color: inherit;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.guestbook-instructions[data-js-enabled="true"] .guestbook-instructions__toggle {
+  display: inline-flex;
+  align-items: center;
+}
+
+.guestbook-instructions__toggle::after {
+  content: "▾";
+  margin-left: 0.5rem;
+  transition: transform 0.2s ease;
+}
+
+.guestbook-instructions__toggle[aria-expanded="true"]::after {
+  transform: rotate(180deg);
+}
+
+.guestbook-instructions__toggle:hover,
+.guestbook-instructions__toggle:focus-visible {
+  background: var(--color-highlight-bg);
+  transform: translateY(-1px);
+}
+
+.guestbook-instructions__content {
+  margin-top: 1rem;
+}
+
+.guestbook-instructions[data-js-enabled="true"][data-state="collapsed"] .guestbook-instructions__content {
+  display: none;
+}
+
+.guestbook-instructions__content ol {
   margin-left: 1.5rem;
   padding-left: 1rem;
 }
 
-.guestbook-how-to li + li {
+.guestbook-instructions__content li + li {
   margin-top: 0.75rem;
 }
 
@@ -1217,8 +1276,14 @@ details#sources[open] > ol {
   font-style: italic;
 }
 
+.guestbook-signatures {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
 .guestbook-root {
-  margin-top: 2rem;
+  margin-top: 0;
 }
 
 .guestbook-status {
@@ -1289,4 +1354,24 @@ details#sources[open] > ol {
 .guestbook-entry__message {
   margin: 0;
   line-height: 1.6;
+}
+
+@media (min-width: 960px) {
+  body[data-section="guestbook"] main {
+    max-width: min(58vw, 720px);
+  }
+
+  .guestbook-layout {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1.5rem;
+  }
+
+  .guestbook-instructions {
+    position: fixed;
+    top: clamp(2rem, 6vh, 4.5rem);
+    right: clamp(1.5rem, 6vw, 4rem);
+    width: min(22rem, 28vw);
+    max-width: 320px;
+  }
 }

--- a/js/guestbook-page.js
+++ b/js/guestbook-page.js
@@ -1,0 +1,38 @@
+(function () {
+  const instructions = document.querySelector("[data-collapsible]");
+  if (!instructions) return;
+
+  const toggle = instructions.querySelector(".guestbook-instructions__toggle");
+  const content = instructions.querySelector(".guestbook-instructions__content");
+  if (!toggle || !content) return;
+
+  const collapsedLabel = "Show instructions";
+  const expandedLabel = "Hide instructions";
+  const breakpoint = window.matchMedia("(min-width: 960px)");
+
+  instructions.dataset.jsEnabled = "true";
+
+  function applyState(isExpanded) {
+    toggle.setAttribute("aria-expanded", String(isExpanded));
+    toggle.textContent = isExpanded ? expandedLabel : collapsedLabel;
+    content.hidden = !isExpanded;
+    instructions.dataset.state = isExpanded ? "expanded" : "collapsed";
+  }
+
+  function syncToBreakpoint(event) {
+    applyState(event.matches);
+  }
+
+  applyState(breakpoint.matches);
+
+  toggle.addEventListener("click", () => {
+    const isExpanded = toggle.getAttribute("aria-expanded") === "true";
+    applyState(!isExpanded);
+  });
+
+  if (typeof breakpoint.addEventListener === "function") {
+    breakpoint.addEventListener("change", syncToBreakpoint);
+  } else if (typeof breakpoint.addListener === "function") {
+    breakpoint.addListener(syncToBreakpoint);
+  }
+})();

--- a/pages/guestbook.html
+++ b/pages/guestbook.html
@@ -31,22 +31,31 @@
   <h1>Guest Book</h1>
   <p class="guestbook-intro">Inspired by the old-school web, this page is a collection of every friendly face that drops by. Add your name and a 16×16 pixel masterpiece so future visitors know you stopped in.</p>
 
-  <section aria-labelledby="guestbook-how-to" class="guestbook-how-to">
-    <h2 id="guestbook-how-to">How to sign your name</h2>
-    <ol>
-      <li>Fork this repository and convert your 16×16 image into a Base64 data URI (for example, run <code>base64 -w 0 my-icon.png</code> and prefix the result with <code>data:image/png;base64,</code>). Skip this step and set <code>"image": "default"</code> if you’d rather use the shared starburst.</li>
-      <li>Edit <code>data/guestbook.json</code> and add your entry object with your name, optional message, link, the Base64 data URI, and a short alt description for the image. Keep the note under 360 characters and the alt text under 120 so every tile stays readable.</li>
-      <li>Open a pull request. The site automatically sanitises your submission so only clean text and safe image paths make it onto the page.</li>
-    </ol>
-    <p class="guestbook-guidelines">We keep things family-friendly and accessible: no hate speech, slurs, flashing imagery, or spam. Entries that don’t follow the rules will be closed without being merged.</p>
-  </section>
+  <div class="guestbook-layout">
+    <section aria-labelledby="guestbook-instructions-title" class="guestbook-instructions" data-collapsible>
+      <div class="guestbook-instructions__header">
+        <h2 id="guestbook-instructions-title" class="guestbook-instructions__title">How to sign your name</h2>
+        <button type="button" class="guestbook-instructions__toggle" aria-expanded="false" aria-controls="guestbook-instructions-content">
+          Show instructions
+        </button>
+      </div>
+      <div id="guestbook-instructions-content" class="guestbook-instructions__content">
+        <ol>
+          <li>Fork this repository and convert your 16×16 image into a Base64 data URI (for example, run <code>base64 -w 0 my-icon.png</code> and prefix the result with <code>data:image/png;base64,</code>). Skip this step and set <code>"image": "default"</code> if you’d rather use the shared starburst.</li>
+          <li>Edit <code>data/guestbook.json</code> and add your entry object with your name, optional message, link, the Base64 data URI, and a short alt description for the image. Keep the note under 360 characters and the alt text under 120 so every tile stays readable.</li>
+          <li>Open a pull request. The site automatically sanitises your submission so only clean text and safe image paths make it onto the page.</li>
+        </ol>
+        <p class="guestbook-guidelines">We keep things family-friendly and accessible: no hate speech, slurs, flashing imagery, or spam. Entries that don’t follow the rules will be closed without being merged.</p>
+      </div>
+    </section>
 
-  <section aria-labelledby="guestbook-signatures">
-    <h2 id="guestbook-signatures">Signatures</h2>
-    <div id="guestbook-root" class="guestbook-root">
-      <p class="guestbook-status">Loading guest book…</p>
-    </div>
-  </section>
+    <section aria-labelledby="guestbook-signatures" class="guestbook-signatures">
+      <h2 id="guestbook-signatures">Signatures</h2>
+      <div id="guestbook-root" class="guestbook-root">
+        <p class="guestbook-status">Loading guest book…</p>
+      </div>
+    </section>
+  </div>
 </main>
 
 <div id="site-footer">
@@ -59,5 +68,6 @@
 
 <script src="/js/site.js" defer></script>
 <script src="/js/guestbook.js" defer></script>
+<script src="/js/guestbook-page.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- reduce the guestbook layout spacing so the signatures sit closer to the top of the page
- constrain the desktop guestbook column width and pin the instructions card to the far right edge of the viewport

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e11529993c833098a0dd0bfade3165