### PR TITLE
Revamp guest book layout and default icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repository powers the static site at [braedensilver.com](https://braedensil
      "imageDescription": "Alt text that describes the icon"
    }
    ```
-   *Only `name` and `image` are required. Use `"default"` for `image` if you want the shared starburst instead. Keep messages under 360 characters and write alt text that screen readers can understand.*
+   *Only `name` and `image` are required. Use `"default"` for `image` if you want the color-shifting shared icon instead. Keep messages under 360 characters and write alt text that screen readers can understand.*
 4. **Open a pull request**. Once merged, the site deploys automatically and your signature appears on [/pages/guestbook.html](https://braedensilver.com/pages/guestbook.html).
 
 Need help checking your Base64 output or want more icon tips? Read [`assets/guestbook/README.md`](assets/guestbook/README.md).

--- a/assets/guestbook/README.md
+++ b/assets/guestbook/README.md
@@ -5,6 +5,6 @@ GitHub’s editor for this project can’t accept binary files, so every guest b
 1. Draw or export a **16×16** PNG, GIF, JPG, or WebP.
 2. Convert it to Base64. On macOS/Linux run `base64 -w 0 my-icon.png` (or `base64 my-icon.png` if your version doesn’t support `-w`). On Windows PowerShell use `[Convert]::ToBase64String([IO.File]::ReadAllBytes("my-icon.png"))`.
 3. Prefix the output with `data:image/png;base64,` (swap `png` for the format you used) and paste it into the `image` field of your guest book entry.
-4. If you’d rather not supply art, set `"image": "default"` to use the built-in lavender starburst.
+4. If you’d rather not supply art, set `"image": "default"` to use the built-in icon that randomises its colours on every load.
 
 Feel free to drop scratch files or conversion notes in this folder while you work — it exists so the directory is always present when you fork the repo — but don’t commit binary assets.

--- a/assets/site.css
+++ b/assets/site.css
@@ -1202,78 +1202,22 @@ details#sources[open] > ol {
   margin-top: 1rem;
 }
 
-.guestbook-instructions {
+.guestbook-guide {
+  align-self: flex-start;
+  max-width: 48ch;
   border: 2px solid var(--color-border);
   border-radius: 0.75rem;
   background: var(--color-panel-muted);
-  padding: 1.25rem;
+  padding: 1rem 1.25rem;
 }
 
-.guestbook-instructions__header {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-}
-
-.guestbook-instructions__title {
+.guestbook-guide__copy {
   margin: 0;
+  font-size: 0.95rem;
 }
 
-.guestbook-instructions__toggle {
-  display: none;
-  margin-left: auto;
-  padding: 0.5rem 0.9rem;
-  border-radius: 999px;
-  border: 2px solid var(--color-border);
-  background: var(--color-bg);
-  color: inherit;
-  font: inherit;
+.guestbook-guide__copy a {
   font-weight: 600;
-  cursor: pointer;
-  transition: background 0.2s ease, transform 0.2s ease;
-}
-
-.guestbook-instructions[data-js-enabled="true"] .guestbook-instructions__toggle {
-  display: inline-flex;
-  align-items: center;
-}
-
-.guestbook-instructions__toggle::after {
-  content: "▾";
-  margin-left: 0.5rem;
-  transition: transform 0.2s ease;
-}
-
-.guestbook-instructions__toggle[aria-expanded="true"]::after {
-  transform: rotate(180deg);
-}
-
-.guestbook-instructions__toggle:hover,
-.guestbook-instructions__toggle:focus-visible {
-  background: var(--color-highlight-bg);
-  transform: translateY(-1px);
-}
-
-.guestbook-instructions__content {
-  margin-top: 1rem;
-}
-
-.guestbook-instructions[data-js-enabled="true"][data-state="collapsed"] .guestbook-instructions__content {
-  display: none;
-}
-
-.guestbook-instructions__content ol {
-  margin-left: 1.5rem;
-  padding-left: 1rem;
-}
-
-.guestbook-instructions__content li + li {
-  margin-top: 0.75rem;
-}
-
-.guestbook-guidelines {
-  margin-top: 1rem;
-  font-style: italic;
 }
 
 .guestbook-signatures {
@@ -1362,16 +1306,12 @@ details#sources[open] > ol {
   }
 
   .guestbook-layout {
-    flex-direction: column;
-    align-items: stretch;
+    align-items: flex-start;
     gap: 1.5rem;
   }
 
-  .guestbook-instructions {
-    position: fixed;
+  .guestbook-guide {
+    position: sticky;
     top: clamp(2rem, 6vh, 4.5rem);
-    right: clamp(1.5rem, 6vw, 4rem);
-    width: min(22rem, 28vw);
-    max-width: 320px;
   }
 }

--- a/js/guestbook.js
+++ b/js/guestbook.js
@@ -9,16 +9,46 @@
     dataUrl: "/data/guestbook.json",
     allowedProtocols: ["http:", "https:"],
     allowedImageMediaTypes: ["image/png", "image/gif", "image/jpeg", "image/webp"],
-    defaultImage:
-      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAVUlEQVR4nGM4suD/fxkJDbIwSC8DjEGOZhDNgC5AimYUA4g1BF0NAzYFHjYVWDE2CzAMgCnEphlEE2UACKMDmPhIMYCiQKQoGilKSBQlZYoyE6XZGQD02s7I2nnE4AAAAABJRU5ErkJggg==",
+    defaultImageTemplate:
+      '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" shape-rendering="crispEdges"><rect x="0" y="0" width="16" height="2" fill="{{DARK}}" /><rect x="0" y="2" width="4" height="1" fill="{{DARK}}" /><rect x="4" y="2" width="8" height="2" fill="{{LIGHT}}" /><rect x="12" y="2" width="4" height="1" fill="{{DARK}}" /><rect x="0" y="3" width="3" height="13" fill="{{DARK}}" /><rect x="3" y="3" width="1" height="5" fill="{{LIGHT}}" /><rect x="12" y="3" width="1" height="5" fill="{{LIGHT}}" /><rect x="13" y="3" width="3" height="13" fill="{{DARK}}" /><rect x="4" y="4" width="2" height="1" fill="{{LIGHT}}" /><rect x="6" y="4" width="4" height="3" fill="{{DARK}}" /><rect x="10" y="4" width="2" height="1" fill="{{LIGHT}}" /><rect x="4" y="5" width="1" height="3" fill="{{LIGHT}}" /><rect x="5" y="5" width="1" height="11" fill="{{DARK}}" /><rect x="10" y="5" width="1" height="2" fill="{{DARK}}" /><rect x="11" y="5" width="1" height="4" fill="{{LIGHT}}" /><rect x="6" y="7" width="3" height="1" fill="{{DARK}}" /><rect x="9" y="7" width="2" height="2" fill="{{LIGHT}}" /><rect x="3" y="8" width="2" height="8" fill="{{DARK}}" /><rect x="6" y="8" width="1" height="8" fill="{{DARK}}" /><rect x="7" y="8" width="2" height="3" fill="{{LIGHT}}" /><rect x="12" y="8" width="1" height="8" fill="{{DARK}}" /><rect x="9" y="9" width="1" height="1" fill="{{LIGHT}}" /><rect x="10" y="9" width="2" height="7" fill="{{DARK}}" /><rect x="9" y="10" width="1" height="6" fill="{{DARK}}" /><rect x="7" y="11" width="2" height="1" fill="{{DARK}}" /><rect x="7" y="12" width="2" height="2" fill="{{LIGHT}}" /><rect x="7" y="14" width="2" height="2" fill="{{DARK}}" /></svg>',
     defaultImageDescription:
-      "Default guest book emblem with a lavender starburst on a deep purple background.",
+      "Default guest book emblem with randomly generated colors.",
     maxNameLength: 60,
     maxMessageLength: 360,
     maxAltLength: 120,
     maxLinkLength: 300,
     maxDataUrlLength: 4096,
   });
+
+  function padHex(value) {
+    return value.toString(16).padStart(2, "0");
+  }
+
+  function randomChannel(min, max) {
+    return Math.floor(Math.random() * (max - min + 1)) + min;
+  }
+
+  function randomColor(range) {
+    const [min, max] = range;
+    const r = padHex(randomChannel(min, max));
+    const g = padHex(randomChannel(min, max));
+    const b = padHex(randomChannel(min, max));
+    return `#${r}${g}${b}`;
+  }
+
+  function buildDefaultImage() {
+    const dark = randomColor([0, 120]);
+    let light = randomColor([180, 255]);
+    if (light === dark) {
+      light = randomColor([180, 255]);
+    }
+
+    const svg = settings.defaultImageTemplate
+      .replace(/\{\{DARK\}\}/g, dark)
+      .replace(/\{\{LIGHT\}\}/g, light);
+
+    return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
+  }
 
   function showStatus(message) {
     root.replaceChildren();
@@ -65,7 +95,7 @@
     }
 
     if (trimmed.toLowerCase() === "default") {
-      return settings.defaultImage;
+      return "default";
     }
 
     if (!trimmed.toLowerCase().startsWith("data:image/")) {
@@ -192,8 +222,8 @@
     }
 
     const sanitizedImage = sanitizeImageSource(candidate.image);
-    const usingDefaultImage = !sanitizedImage;
-    const image = usingDefaultImage ? settings.defaultImage : sanitizedImage;
+    const usingDefaultImage = sanitizedImage === "default" || !sanitizedImage;
+    const image = usingDefaultImage ? buildDefaultImage() : sanitizedImage;
     const message = sanitizeOptionalText(candidate.message, settings.maxMessageLength);
     const link = sanitizeLink(candidate.link);
     let imageDescription = sanitizeOptionalText(candidate.imageDescription, settings.maxAltLength);
@@ -215,6 +245,8 @@
       const sanitized = entries
         .map(normalizeEntry)
         .filter(Boolean);
+
+      sanitized.reverse();
 
       if (!sanitized.length) {
         showStatus("No signatures yet. Be the first to add yours!");

--- a/pages/guestbook.html
+++ b/pages/guestbook.html
@@ -4,9 +4,9 @@
   <meta charset="utf-8">
   <title>Guest Book — Braeden Silver</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="Sign Braeden Silver's guest book with your name and a 16×16 calling card.">
+  <meta name="description" content="Leave a quick hello for Braeden Silver and see the newest guest book signatures first.">
   <meta property="og:title" content="Guest Book — Braeden Silver">
-  <meta property="og:description" content="Sign Braeden Silver's guest book with your name and a 16×16 calling card.">
+  <meta property="og:description" content="Leave a quick hello for Braeden Silver and see the newest guest book signatures first.">
   <meta property="og:image" content="https://braedensilver.com/favicon.ico">
   <link rel="stylesheet" href="/assets/site.css">
 </head>
@@ -29,32 +29,19 @@
   </nav>
 
   <h1>Guest Book</h1>
-  <p class="guestbook-intro">Inspired by the old-school web, this page is a collection of every friendly face that drops by. Add your name and a 16×16 pixel masterpiece so future visitors know you stopped in.</p>
+  <p class="guestbook-intro">Say hello, share what you're working on, or drop a fun fact. Fresh signatures float to the top while the archives stay below for a stroll down memory lane.</p>
 
   <div class="guestbook-layout">
-    <section aria-labelledby="guestbook-instructions-title" class="guestbook-instructions" data-collapsible>
-      <div class="guestbook-instructions__header">
-        <h2 id="guestbook-instructions-title" class="guestbook-instructions__title">How to sign your name</h2>
-        <button type="button" class="guestbook-instructions__toggle" aria-expanded="false" aria-controls="guestbook-instructions-content">
-          Show instructions
-        </button>
-      </div>
-      <div id="guestbook-instructions-content" class="guestbook-instructions__content">
-        <ol>
-          <li>Fork this repository and convert your 16×16 image into a Base64 data URI (for example, run <code>base64 -w 0 my-icon.png</code> and prefix the result with <code>data:image/png;base64,</code>). Skip this step and set <code>"image": "default"</code> if you’d rather use the shared starburst.</li>
-          <li>Edit <code>data/guestbook.json</code> and add your entry object with your name, optional message, link, the Base64 data URI, and a short alt description for the image. Keep the note under 360 characters and the alt text under 120 so every tile stays readable.</li>
-          <li>Open a pull request. The site automatically sanitises your submission so only clean text and safe image paths make it onto the page.</li>
-        </ol>
-        <p class="guestbook-guidelines">We keep things family-friendly and accessible: no hate speech, slurs, flashing imagery, or spam. Entries that don’t follow the rules will be closed without being merged.</p>
-      </div>
-    </section>
-
     <section aria-labelledby="guestbook-signatures" class="guestbook-signatures">
       <h2 id="guestbook-signatures">Signatures</h2>
       <div id="guestbook-root" class="guestbook-root">
         <p class="guestbook-status">Loading guest book…</p>
       </div>
     </section>
+
+    <aside class="guestbook-guide">
+      <p class="guestbook-guide__copy">Want to add your name? <a href="https://github.com/BraedenSilver/BraedenSilver.github.io#sign-the-guest-book" rel="noopener noreferrer">Follow the GitHub instructions.</a></p>
+    </aside>
   </div>
 </main>
 


### PR DESCRIPTION
## Summary
- replace the on-page instructions with a short link to the GitHub guide and move the signature grid to the top of the layout
- restyle the guest book page to match the new layout and update descriptions for the refreshed intro copy
- generate a randomized SVG for the default avatar and render newer signatures first, updating docs to match

## Testing
- No automated tests (static site)

------
https://chatgpt.com/codex/tasks/task_e_68e1256a66c48330bd22c626a9d0e03c