### PR TITLE
Use hosted default guestbook avatar

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository powers the static site at [braedensilver.com](https://braedensil
 ## Sign the guest book
 
 1. **Fork** this repository.
-2. **Prepare your icon**: export a 16×16 image (PNG, GIF, JPG, or WebP under ~10&nbsp;KB) and convert it to a Base64 string. On macOS/Linux you can run `base64 your-icon.png` (or `base64 -w 0 your-icon.png` to avoid line wraps). Keep the output handy — we embed it directly in the JSON file so no binary files need to be committed.
+2. **Prepare your icon**: export a 16×16 image (PNG, GIF, JPG, or WebP under ~10&nbsp;KB). You can either convert it to a Base64 string (run `base64 -w 0 your-icon.png` on macOS/Linux or `[Convert]::ToBase64String([IO.File]::ReadAllBytes("my-icon.png"))` in Windows PowerShell) or commit the file to `assets/guestbook/`.
 3. **Append your entry** in `data/guestbook.json`:
    ```json
    {
@@ -16,14 +16,10 @@ This repository powers the static site at [braedensilver.com](https://braedensil
      "imageDescription": "Alt text that describes the icon"
    }
    ```
-   *Only `name` and `image` are required. Use `"default"` for `image` if you want the color-shifting shared icon instead. Keep messages under 360 characters and write alt text that screen readers can understand.*
+   *Only `name` and `image` are required. If you uploaded a file, reference it like `"/assets/guestbook/your-icon.png"`. Use `"default"` (or simply omit the field) to display the shared crest stored at `/assets/guestbook/default.svg`. Keep messages under 360 characters and write alt text that screen readers can understand.*
 4. **Open a pull request**. Once merged, the site deploys automatically and your signature appears on [/pages/guestbook.html](https://braedensilver.com/pages/guestbook.html).
 
 Need help checking your Base64 output or want more icon tips? Read [`assets/guestbook/README.md`](assets/guestbook/README.md).
-
-## Safety filters
-
-The guest book is rendered client-side by `js/guestbook.js`, which strips control characters, rejects oversize data URIs, ignores entries with missing data, and only allows embedded `data:image/*;base64` icons or the shared default. Links are limited to `http`/`https` URLs and open in a new tab with `rel="nofollow"`. If you try to sneak in scripts or remote resources, they simply will not render.
 
 ## House rules
 

--- a/assets/guestbook/README.md
+++ b/assets/guestbook/README.md
@@ -1,10 +1,12 @@
 # Guest book icon storage
 
-GitHub’s editor for this project can’t accept binary files, so every guest book avatar lives as a Base64 data URI inside `data/guestbook.json`. If you want to prepare your own art:
+Drop any shared guest book artwork in this folder. Each entry in `data/guestbook.json` can either embed a Base64 data URI or reference one of these files with a path like `/assets/guestbook/your-icon.png`.
+
+To prepare a new icon:
 
 1. Draw or export a **16×16** PNG, GIF, JPG, or WebP.
-2. Convert it to Base64. On macOS/Linux run `base64 -w 0 my-icon.png` (or `base64 my-icon.png` if your version doesn’t support `-w`). On Windows PowerShell use `[Convert]::ToBase64String([IO.File]::ReadAllBytes("my-icon.png"))`.
-3. Prefix the output with `data:image/png;base64,` (swap `png` for the format you used) and paste it into the `image` field of your guest book entry.
-4. If you’d rather not supply art, set `"image": "default"` to use the built-in icon that randomises its colours on every load.
+2. Either convert it to Base64 (run `base64 -w 0 my-icon.png` on macOS/Linux or `[Convert]::ToBase64String([IO.File]::ReadAllBytes("my-icon.png"))` in Windows PowerShell) or save the file directly in this directory.
+3. Update `data/guestbook.json` with your details. If you saved a file here, reference it with its `/assets/guestbook/...` path. If you used Base64, paste the string into the `image` field.
+4. Skip the `image` field or set it to `"default"` if you want the shared crest stored at `/assets/guestbook/default.svg`.
 
-Feel free to drop scratch files or conversion notes in this folder while you work — it exists so the directory is always present when you fork the repo — but don’t commit binary assets.
+You can also use this directory for temporary working files while preparing your art.

--- a/data/guestbook.json
+++ b/data/guestbook.json
@@ -4,7 +4,7 @@
       "name": "Braeden Silver",
       "message": "Welcome to the permanent guest book! Leave your pixel calling card so I know you were here.",
       "link": "https://braedensilver.com",
-      "image": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAAALElEQVR42mP4f8TBW78ejghyGUhSDSQZSFKN0EC8wxhIUg3SMOrpUU9j5wIAH9wvGBwzFTwAAAAASUVORK5CYII=",
+      "image": "/assets/guestbook/braedensilver.png",
       "imageDescription": "Gold sparks on a purple field"
     }
   ]

--- a/js/guestbook.js
+++ b/js/guestbook.js
@@ -9,46 +9,16 @@
     dataUrl: "/data/guestbook.json",
     allowedProtocols: ["http:", "https:"],
     allowedImageMediaTypes: ["image/png", "image/gif", "image/jpeg", "image/webp"],
-    defaultImageTemplate:
-      '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" shape-rendering="crispEdges"><rect x="0" y="0" width="16" height="2" fill="{{DARK}}" /><rect x="0" y="2" width="4" height="1" fill="{{DARK}}" /><rect x="4" y="2" width="8" height="2" fill="{{LIGHT}}" /><rect x="12" y="2" width="4" height="1" fill="{{DARK}}" /><rect x="0" y="3" width="3" height="13" fill="{{DARK}}" /><rect x="3" y="3" width="1" height="5" fill="{{LIGHT}}" /><rect x="12" y="3" width="1" height="5" fill="{{LIGHT}}" /><rect x="13" y="3" width="3" height="13" fill="{{DARK}}" /><rect x="4" y="4" width="2" height="1" fill="{{LIGHT}}" /><rect x="6" y="4" width="4" height="3" fill="{{DARK}}" /><rect x="10" y="4" width="2" height="1" fill="{{LIGHT}}" /><rect x="4" y="5" width="1" height="3" fill="{{LIGHT}}" /><rect x="5" y="5" width="1" height="11" fill="{{DARK}}" /><rect x="10" y="5" width="1" height="2" fill="{{DARK}}" /><rect x="11" y="5" width="1" height="4" fill="{{LIGHT}}" /><rect x="6" y="7" width="3" height="1" fill="{{DARK}}" /><rect x="9" y="7" width="2" height="2" fill="{{LIGHT}}" /><rect x="3" y="8" width="2" height="8" fill="{{DARK}}" /><rect x="6" y="8" width="1" height="8" fill="{{DARK}}" /><rect x="7" y="8" width="2" height="3" fill="{{LIGHT}}" /><rect x="12" y="8" width="1" height="8" fill="{{DARK}}" /><rect x="9" y="9" width="1" height="1" fill="{{LIGHT}}" /><rect x="10" y="9" width="2" height="7" fill="{{DARK}}" /><rect x="9" y="10" width="1" height="6" fill="{{DARK}}" /><rect x="7" y="11" width="2" height="1" fill="{{DARK}}" /><rect x="7" y="12" width="2" height="2" fill="{{LIGHT}}" /><rect x="7" y="14" width="2" height="2" fill="{{DARK}}" /></svg>',
-    defaultImageDescription:
-      "Default guest book emblem with randomly generated colors.",
+    allowedImagePathPrefix: "/assets/guestbook/",
+    allowedImageFileExtensions: ["png", "gif", "jpeg", "jpg", "webp"],
+    defaultImagePath: "/assets/guestbook/default.svg",
+    defaultImageDescription: "Black and white emblem with a pixel crest.",
     maxNameLength: 60,
     maxMessageLength: 360,
     maxAltLength: 120,
     maxLinkLength: 300,
     maxDataUrlLength: 4096,
   });
-
-  function padHex(value) {
-    return value.toString(16).padStart(2, "0");
-  }
-
-  function randomChannel(min, max) {
-    return Math.floor(Math.random() * (max - min + 1)) + min;
-  }
-
-  function randomColor(range) {
-    const [min, max] = range;
-    const r = padHex(randomChannel(min, max));
-    const g = padHex(randomChannel(min, max));
-    const b = padHex(randomChannel(min, max));
-    return `#${r}${g}${b}`;
-  }
-
-  function buildDefaultImage() {
-    const dark = randomColor([0, 120]);
-    let light = randomColor([180, 255]);
-    if (light === dark) {
-      light = randomColor([180, 255]);
-    }
-
-    const svg = settings.defaultImageTemplate
-      .replace(/\{\{DARK\}\}/g, dark)
-      .replace(/\{\{LIGHT\}\}/g, light);
-
-    return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
-  }
 
   function showStatus(message) {
     root.replaceChildren();
@@ -95,10 +65,53 @@
     }
 
     if (trimmed.toLowerCase() === "default") {
-      return "default";
+      return settings.defaultImagePath;
     }
 
-    if (!trimmed.toLowerCase().startsWith("data:image/")) {
+    const lowerTrimmed = trimmed.toLowerCase();
+    const prefixesToCheck = [
+      settings.allowedImagePathPrefix,
+      settings.allowedImagePathPrefix.startsWith("/")
+        ? settings.allowedImagePathPrefix.slice(1)
+        : settings.allowedImagePathPrefix,
+    ].filter(Boolean);
+
+    const matchedPrefix = prefixesToCheck.find(prefix =>
+      lowerTrimmed.startsWith(prefix.toLowerCase())
+    );
+
+    if (matchedPrefix) {
+      const suffix = trimmed.slice(matchedPrefix.length);
+      const normalizedSuffix = suffix.replace(/^\/+/, "");
+      const normalizedPath = `${settings.allowedImagePathPrefix}${normalizedSuffix}`;
+      if (!normalizedPath.startsWith(settings.allowedImagePathPrefix)) {
+        return null;
+      }
+      if (!normalizedSuffix) {
+        return null;
+      }
+      if (normalizedPath.includes("..")) {
+        return null;
+      }
+
+      const extension = normalizedPath.split(".").pop();
+      if (!extension) {
+        return null;
+      }
+
+      const normalizedExtension = extension.toLowerCase() === "jpg" ? "jpeg" : extension.toLowerCase();
+      const allowedExtensions = settings.allowedImageFileExtensions.map(ext =>
+        ext.toLowerCase() === "jpg" ? "jpeg" : ext.toLowerCase()
+      );
+
+      if (!allowedExtensions.includes(normalizedExtension)) {
+        return null;
+      }
+
+      return normalizedPath;
+    }
+
+    if (!lowerTrimmed.startsWith("data:image/")) {
       return null;
     }
 
@@ -222,8 +235,8 @@
     }
 
     const sanitizedImage = sanitizeImageSource(candidate.image);
-    const usingDefaultImage = sanitizedImage === "default" || !sanitizedImage;
-    const image = usingDefaultImage ? buildDefaultImage() : sanitizedImage;
+    const usingDefaultImage = !sanitizedImage || sanitizedImage === settings.defaultImagePath;
+    const image = usingDefaultImage ? settings.defaultImagePath : sanitizedImage;
     const message = sanitizeOptionalText(candidate.message, settings.maxMessageLength);
     const link = sanitizeLink(candidate.link);
     let imageDescription = sanitizeOptionalText(candidate.imageDescription, settings.maxAltLength);


### PR DESCRIPTION
## Summary
- serve the default guestbook fallback from the hosted `/assets/guestbook/default.svg` crest
- refresh contributor docs to explain referencing uploaded assets and omit the security blurb
- update the guestbook asset README with the new workflow for files or Base64 data

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e12a1a27508330a7fb09093369b894