### PR TITLE
Automatically resolve guest book discussion IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ If you fork this project or need to update the giscus settings:
 
 1. Enable **GitHub Discussions** on the repository and create a category (for example, “Guestbook”).
 2. Visit [giscus.app](https://giscus.app) and copy the generated repository, discussion category, and ID values.
-3. Update the JSON block with `id="guestbook-config"` in [`pages/guestbook.html`](pages/guestbook.html) so the `repoId` and `categoryId` fields contain your values. Adjust `discussionTerm` if you rename the thread.
-   - _Final touches:_ Replace the `REPLACE_WITH_REPO_ID` and `REPLACE_WITH_CATEGORY_ID` placeholders with the IDs that giscus gives you. As soon as those strings are swapped out, the embed finishes loading and the guest book is fully wired to the discussion.
+3. Update the JSON block with `id="guestbook-config"` in [`pages/guestbook.html`](pages/guestbook.html).
+   - The embed now fetches missing `repoId` and `categoryId` values directly from the GitHub API. Add them to the config anyway to avoid extra API calls and rate limits.
 4. (Optional) Tweak the light and dark iframe themes in [`assets/giscus-theme-light.css`](assets/giscus-theme-light.css) and [`assets/giscus-theme-dark.css`](assets/giscus-theme-dark.css) to match your brand colors.
 
 ## House rules

--- a/js/guestbook-giscus.js
+++ b/js/guestbook-giscus.js
@@ -1,4 +1,4 @@
-(function () {
+(async function () {
   const SECTION_ID = "guestbook";
   if (document.body?.dataset?.section !== SECTION_ID) {
     return;
@@ -39,17 +39,128 @@
     return;
   }
 
-  const requiredKeys = ["repo", "repoId", "category", "categoryId", "discussionTerm", "discussionUrl"];
-  const missingKeys = requiredKeys.filter((key) => {
-    const value = config[key];
-    return !value || typeof value !== "string" || !value.trim() || /REPLACE_WITH/i.test(value);
-  });
+  const isValidString = (value) => typeof value === "string" && value.trim() && !/REPLACE_WITH/i.test(value);
+
+  const requiredKeys = ["repo", "category", "discussionTerm", "discussionUrl"];
+  const missingKeys = requiredKeys.filter((key) => !isValidString(config[key]));
 
   if (missingKeys.length > 0) {
     showStatus(
       "The guest book isn't configured yet. Update the discussion settings in the page source to finish setup.",
       { isError: true },
     );
+    return;
+  }
+
+  const repo = config.repo.trim();
+  const category = config.category.trim();
+
+  function normalizeRepo(value) {
+    return value
+      .split("/")
+      .map((segment, index) => {
+        if (index > 1) {
+          return segment;
+        }
+        return segment.trim();
+      })
+      .slice(0, 2)
+      .join("/");
+  }
+
+  const repoSlug = normalizeRepo(repo);
+
+  async function resolveRepoId() {
+    if (isValidString(config.repoId)) {
+      return config.repoId.trim();
+    }
+
+    showStatus("Connecting to GitHub…");
+
+    const controller = new AbortController();
+    const timeout = window.setTimeout(() => controller.abort(), 10000);
+
+    try {
+      const response = await fetch(`https://api.github.com/repos/${repoSlug}`, {
+        headers: {
+          Accept: "application/vnd.github+json",
+        },
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        throw new Error(`Request failed: ${response.status}`);
+      }
+
+      const data = await response.json();
+      if (isValidString(data?.node_id)) {
+        config.repoId = data.node_id.trim();
+        return config.repoId;
+      }
+    } catch (error) {
+      console.error("Failed to resolve repoId", error);
+      showStatus(
+        "We couldn't confirm the discussion settings with GitHub. Open the guest book on GitHub Discussions while we investigate.",
+        { isError: true },
+      );
+      throw error;
+    } finally {
+      window.clearTimeout(timeout);
+    }
+  }
+
+  async function resolveCategoryId() {
+    if (isValidString(config.categoryId)) {
+      return config.categoryId.trim();
+    }
+
+    showStatus("Checking discussion category…");
+
+    const controller = new AbortController();
+    const timeout = window.setTimeout(() => controller.abort(), 10000);
+
+    try {
+      const response = await fetch(`https://api.github.com/repos/${repoSlug}/discussions/categories`, {
+        headers: {
+          Accept: "application/vnd.github+json",
+        },
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        throw new Error(`Request failed: ${response.status}`);
+      }
+
+      const categories = await response.json();
+      const match = (Array.isArray(categories) ? categories : []).find((item) => {
+        if (!item || typeof item !== "object") {
+          return false;
+        }
+        const name = typeof item.name === "string" ? item.name.trim() : "";
+        return name.toLowerCase() === category.toLowerCase();
+      });
+
+      const nodeId = match?.node_id || match?.id;
+      if (isValidString(nodeId)) {
+        config.categoryId = nodeId.trim();
+        return config.categoryId;
+      }
+    } catch (error) {
+      console.error("Failed to resolve categoryId", error);
+      showStatus(
+        "We couldn't find the discussion category on GitHub. Open the guest book on GitHub Discussions while we investigate.",
+        { isError: true },
+      );
+      throw error;
+    } finally {
+      window.clearTimeout(timeout);
+    }
+  }
+
+  try {
+    await Promise.all([resolveRepoId(), resolveCategoryId()]);
+  } catch (error) {
+    console.error("Guest book initialization halted", error);
     return;
   }
 

--- a/pages/guestbook.html
+++ b/pages/guestbook.html
@@ -61,11 +61,11 @@
 <script type="application/json" id="guestbook-config">
 {
   "repo": "BraedenSilver/BraedenSilver.github.io",
-  "repoId": "REPLACE_WITH_REPO_ID",
+  "repoId": null,
   "category": "Guestbook",
-  "categoryId": "REPLACE_WITH_CATEGORY_ID",
+  "categoryId": null,
   "discussionTerm": "Guest Book",
-  "discussionUrl": "https://github.com/BraedenSilver/BraedenSilver.github.io/discussions",
+  "discussionUrl": "https://github.com/BraedenSilver/BraedenSilver.github.io/discussions/78",
   "theme": {
     "light": "/assets/giscus-theme-light.css",
     "dark": "/assets/giscus-theme-dark.css"


### PR DESCRIPTION
## Summary
- allow the guest book loader to fetch missing GitHub repository and category identifiers before embedding giscus
- point the guest book configuration at the existing discussion thread and use null placeholders for IDs by default
- update the maintainer guide to mention the automatic ID lookup and encourage setting explicit values

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e13cca66708330a396a569a5490dc8