### PR TITLE
Move guest book to dedicated page

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,6 +59,13 @@
       <img src="/assets/arrowleft.gif" alt="" class="arrow" aria-hidden="true" loading="lazy" decoding="async">
     </a>
   </li>
+  <li>
+    <a class="project-entry quick-link" href="/pages/guest-book.html">
+      <img src="/assets/arrowright.gif" alt="" class="arrow" aria-hidden="true" loading="lazy" decoding="async">
+      <span class="quick-link-label">Guest Book</span>
+      <img src="/assets/arrowleft.gif" alt="" class="arrow" aria-hidden="true" loading="lazy" decoding="async">
+    </a>
+  </li>
 </ul>
 
 <figure class="blog-mascot">

--- a/js/site.js
+++ b/js/site.js
@@ -7,6 +7,7 @@ const SITE_CONTENT = Object.freeze({
     { href: "/pages/projects/index.html", section: "projects", label: "Projects" },
     { href: "/pages/research/index.html", section: "research", label: "Research" },
     { href: "/pages/blog/index.html", section: "blog", label: "Blog" },
+    { href: "/pages/guest-book.html", section: "guest-book", label: "Guest Book" },
     { href: "/pages/contact.html", section: "contact", label: "Contact" },
   ],
   announcementText: "Total Site Overhaul, Happy Oktoberfest and Happy Halloween!",

--- a/pages/guest-book.html
+++ b/pages/guest-book.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Guest Book — Braeden Silver</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Sign the guest book to share how you found Braeden Silver or leave a friendly note.">
+  <meta property="og:title" content="Guest Book — Braeden Silver">
+  <meta property="og:description" content="Sign the guest book to share how you found Braeden Silver or leave a friendly note.">
+  <meta property="og:image" content="/assets/dino-mail.gif">
+  <link rel="stylesheet" href="/assets/site.css">
+</head>
+<body data-section="guest-book">
+
+<!-- Header and footer are injected by js/site.js -->
+<div id="site-header">
+  <noscript>
+    <div class="noscript-banner" role="alert">
+      This website needs JavaScript to work, what are you doing by having it turned off!!!
+    </div>
+  </noscript>
+</div>
+
+<main>
+  <nav class="page-back" aria-label="Back navigation">
+    <a class="project-entry back-link" href="/index.html" data-history-back aria-label="Go back to the previous page">
+      <span class="back-link-icon" aria-hidden="true">←</span>
+      <span class="back-link-label">Go back to the previous page</span>
+    </a>
+  </nav>
+
+  <h1>Guest Book</h1>
+  <p>Thanks for stopping by! Share how you found the site, what you're working on, or just say hello.</p>
+
+  <section aria-labelledby="guestbook-heading" class="guestbook">
+    <h2 id="guestbook-heading" class="visually-hidden">Guest book messages</h2>
+    <div class="guestbook-thread" data-nosnippet>
+      <script src="https://giscus.app/client.js"
+              data-repo="BraedenSilver/BraedenSilver.github.io"
+              data-repo-id="R_kgDOM1hCqg"
+              data-category="General"
+              data-category-id="DIC_kwDOM1hCqs4CwPl_"
+              data-mapping="pathname"
+              data-strict="0"
+              data-reactions-enabled="1"
+              data-emit-metadata="0"
+              data-input-position="bottom"
+              data-theme="preferred_color_scheme"
+              data-lang="en"
+              crossorigin="anonymous"
+              async>
+      </script>
+      <noscript>
+        <p>Enable JavaScript to view and sign the guest book via Giscus.</p>
+      </noscript>
+    </div>
+  </section>
+</main>
+
+<div id="site-footer">
+  <noscript>
+    <div class="noscript-banner" role="alert">
+      This website needs JavaScript to work, what are you doing by having it turned off!!!
+    </div>
+  </noscript>
+</div>
+<script src="/js/site.js" defer></script>
+</body>
+</html>

--- a/partials/header.html
+++ b/partials/header.html
@@ -32,6 +32,7 @@
       <a href="/pages/projects/index.html" data-section="projects">Projects</a> ·
       <a href="/pages/research/index.html" data-section="research">Research</a> ·
       <a href="/pages/blog/index.html" data-section="blog">Blog</a> ·
+      <a href="/pages/guest-book.html" data-section="guest-book">Guest Book</a> ·
       <a href="/pages/contact.html" data-section="contact">Contact</a>
     </nav>
     <button type="button" class="theme-toggle" data-theme-toggle aria-label="Activate dark mode" aria-pressed="false">


### PR DESCRIPTION
## Summary
- remove the guest book embed from the homepage quick links area
- add a dedicated Guest Book page that embeds the Giscus discussion widget
- expose the new page through the global navigation and homepage quick links

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1589307608330a6745a07783cbb3b