### PR TITLE
Fix rendering of embedded HTML in blog paragraphs

### DIFF
--- a/js/blog.js
+++ b/js/blog.js
@@ -249,6 +249,22 @@ function createParagraphBlock(text, htmlOverride) {
     return block;
   }
 
+  if (cleanText && cleanText !== escapeHtml(cleanText)) {
+    const scratch = document.createElement("div");
+    scratch.innerHTML = cleanText;
+    if (scratch.querySelector("*")) {
+      const sanitizedHtml = scratch.innerHTML.trim();
+      if (sanitizedHtml) {
+        block.html = sanitizedHtml;
+        const textContent = scratch.textContent ? scratch.textContent.trim() : "";
+        if (textContent) {
+          block.text = textContent;
+        }
+        return block;
+      }
+    }
+  }
+
   if (cleanText) {
     const { html, containsLink } = linkifyText(cleanText);
     if (containsLink) {


### PR DESCRIPTION
## Summary
- detect pre-authored HTML snippets in blog paragraph text and render them as markup
- ensure inline anchor tags in blog post bodies display as links instead of escaped text

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1d33dba188330a9c4790c0bd70303