### PR TITLE
Add dynamic version number to footer

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -1162,6 +1162,13 @@ details#sources[open] > ol {
   color: var(--color-subtle-text);
 }
 
+.footer-static .footer-version {
+  margin: 0.35rem 0 0;
+  font-size: 0.8rem;
+  color: var(--color-subtle-text);
+  letter-spacing: 0.02em;
+}
+
 .footer-static .footer-note a[aria-current="page"] {
   font-weight: 600;
   text-decoration: underline;

--- a/js/site.js
+++ b/js/site.js
@@ -193,6 +193,10 @@ function renderFooter() {
 </footer>
 <footer class="footer-static">
   <p class="footer-note">© 2025 Braeden Silver. All rights reserved.</p>
+  <p class="footer-version">
+    Version
+    <span data-footer-version data-version-prefix="V0.1." data-version-fallback="194">V0.1.194</span>
+  </p>
 </footer>`;
 }
 
@@ -425,6 +429,56 @@ async function updateLastUpdated() {
     undefined,
     opts,
   );
+}
+
+const FOOTER_VERSION_ENDPOINT =
+  "https://api.github.com/repos/BraedenSilver/BraedenSilver.github.io/commits?per_page=1";
+
+async function fetchCommitCount() {
+  const response = await fetch(FOOTER_VERSION_ENDPOINT, {
+    headers: { Accept: "application/vnd.github+json" },
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub responded with ${response.status}`);
+  }
+
+  const linkHeader = response.headers.get("Link");
+  if (linkHeader) {
+    const match = linkHeader.match(/&page=(\d+)>; rel="last"/);
+    if (match) {
+      const count = Number.parseInt(match[1], 10);
+      if (Number.isFinite(count) && count > 0) {
+        return count;
+      }
+    }
+  }
+
+  const commits = await response.json();
+  return Array.isArray(commits) ? commits.length : 0;
+}
+
+async function updateFooterVersion() {
+  const target = document.querySelector("[data-footer-version]");
+  if (!target) return;
+
+  const prefix = target.dataset.versionPrefix ?? "";
+  const fallbackCount = target.dataset.versionFallback ?? "";
+  const fallbackValue = fallbackCount ? `${prefix}${fallbackCount}` : target.textContent;
+
+  try {
+    const count = await fetchCommitCount();
+    if (Number.isFinite(count) && count > 0) {
+      target.textContent = `${prefix}${count}`;
+      return;
+    }
+  } catch (error) {
+    console.warn("Failed to load commit count", error);
+  }
+
+  if (fallbackValue) {
+    target.textContent = fallbackValue;
+  }
 }
 
 const CUSTOM_CURSOR_ENABLED = false;
@@ -903,7 +957,11 @@ window.addEventListener("DOMContentLoaded", async () => {
   initHistoryBackLinks();
   initShareLink();
 
-  await Promise.all([initContentRenderers(), updateLastUpdated()]);
+  await Promise.all([
+    initContentRenderers(),
+    updateLastUpdated(),
+    updateFooterVersion(),
+  ]);
   if (window.matchMedia("(pointer: fine)").matches) {
     initCustomCursor();
   }

--- a/partials/footer.html
+++ b/partials/footer.html
@@ -27,6 +27,15 @@
 </footer>
 <footer class="footer-static">
   <p class="footer-note">© 2025 Braeden Silver. All rights reserved.</p>
+  <p class="footer-version">
+    Version
+    <span
+      data-footer-version
+      data-version-prefix="V0.1."
+      data-version-fallback="194"
+      >V0.1.194</span
+    >
+  </p>
 </footer>
 
 <!-- Styles moved to /assets/site.css -->


### PR DESCRIPTION
## Summary
- add a version line to the static footer with a fallback commit count
- style the footer version text to match the existing footer aesthetic
- fetch the repository commit count from the GitHub API and update the footer version on load

## Testing
- No tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e1dd9d50ac8330a5b5cb9e5c64b547