### PR TITLE
Match footer version link typography

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -595,6 +595,28 @@ html.theme-dark .theme-toggle__icon--moon {
 
 .last-updated {
   margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.last-updated .footer-version {
+  font-size: inherit;
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.15em;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.25rem;
+  transition: color 0.2s ease, text-decoration-thickness 0.2s ease;
+}
+
+.last-updated .footer-version:hover,
+.last-updated .footer-version:focus-visible {
+  color: var(--color-strong-text);
+  text-decoration-thickness: 2px;
 }
 
 .footer-share {
@@ -1160,13 +1182,6 @@ details#sources[open] > ol {
   margin: 0;
   font-size: 0.9rem;
   color: var(--color-subtle-text);
-}
-
-.footer-static .footer-version {
-  margin: 0.35rem 0 0;
-  font-size: 0.8rem;
-  color: var(--color-subtle-text);
-  letter-spacing: 0.02em;
 }
 
 .footer-static .footer-note a[aria-current="page"] {

--- a/js/site.js
+++ b/js/site.js
@@ -176,7 +176,20 @@ function renderFooter() {
 <footer class="footer-fixed">
   <div class="footer-bar">
     <div class="footer-meta">
-      <p class="last-updated">Last updated: <span id="last-updated">See Git history</span></p>
+      <p class="last-updated">
+        Last updated: <span id="last-updated">See Git history</span>
+        <a
+          class="footer-version"
+          href="https://github.com/BraedenSilver/BraedenSilver.github.io"
+        >
+          Version
+          <span
+            data-footer-version
+            data-version-prefix="V0.1."
+            data-version-fallback="194"
+          >V0.1.194</span>
+        </a>
+      </p>
       <button type="button" class="footer-share" data-share-button>
         Copy page link
       </button>
@@ -193,10 +206,6 @@ function renderFooter() {
 </footer>
 <footer class="footer-static">
   <p class="footer-note">© 2025 Braeden Silver. All rights reserved.</p>
-  <p class="footer-version">
-    Version
-    <span data-footer-version data-version-prefix="V0.1." data-version-fallback="194">V0.1.194</span>
-  </p>
 </footer>`;
 }
 

--- a/partials/footer.html
+++ b/partials/footer.html
@@ -4,6 +4,18 @@
       <!-- Last updated text is filled in by JavaScript -->
       <p class="last-updated">
         Last updated: <span id="last-updated">See Git history</span>
+        <a
+          class="footer-version"
+          href="https://github.com/BraedenSilver/BraedenSilver.github.io"
+        >
+          Version
+          <span
+            data-footer-version
+            data-version-prefix="V0.1."
+            data-version-fallback="194"
+            >V0.1.194</span
+          >
+        </a>
       </p>
       <!-- Share button triggers the clipboard helper in js/site.js -->
       <button type="button" class="footer-share" data-share-button>
@@ -27,15 +39,6 @@
 </footer>
 <footer class="footer-static">
   <p class="footer-note">© 2025 Braeden Silver. All rights reserved.</p>
-  <p class="footer-version">
-    Version
-    <span
-      data-footer-version
-      data-version-prefix="V0.1."
-      data-version-fallback="194"
-      >V0.1.194</span
-    >
-  </p>
 </footer>
 
 <!-- Styles moved to /assets/site.css -->


### PR DESCRIPTION
## Summary
- let the footer version link inherit the base typography so it matches the Last updated copy
- keep the link inline with subtle underline styling while preserving hover feedback

## Testing
- Not run (static content change)

------
https://chatgpt.com/codex/tasks/task_e_68e1df66345c8330a9c0afa891608ed6