### PR TITLE
Fix footer version link hover contrast

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -615,7 +615,7 @@ html.theme-dark .theme-toggle__icon--moon {
 
 .last-updated .footer-version:hover,
 .last-updated .footer-version:focus-visible {
-  color: var(--color-strong-text);
+  color: var(--color-text);
   text-decoration-thickness: 2px;
 }
 


### PR DESCRIPTION
## Summary
- update the footer version link hover state to keep the text visible in both color schemes

## Testing
- no automated tests run

------
https://chatgpt.com/codex/tasks/task_e_68e1e333bc248330859dd1e4ebab3874