### PR TITLE
Adjust announcement marquee direction

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -361,11 +361,11 @@ html.theme-dark .theme-toggle__icon--moon {
 
 @keyframes announcement-scroll {
   0% {
-    transform: translateX(0);
+    transform: translateX(100%);
   }
 
   100% {
-    transform: translateX(-50%);
+    transform: translateX(-100%);
   }
 }
 


### PR DESCRIPTION
## Summary
- update the announcement marquee animation so the message enters from the right and exits fully to the left before repeating

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68e2d6f88e4883308ed45000079e6a59