### PR TITLE
Align blog cards with bottom-left tags and expand home feed

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -1122,6 +1122,39 @@ details#sources[open] > ol {
   font-style: italic;
 }
 
+.random-entry-button {
+  align-self: flex-start;
+  border: 2px solid var(--color-border);
+  background: var(--color-surface);
+  border-radius: 12px;
+  padding: 0.55rem 1.25rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  box-shadow: 3px 3px 0 var(--color-shadow);
+  transition: transform 0.15s ease, box-shadow 0.15s ease,
+    background 0.15s ease, color 0.15s ease;
+}
+
+.random-entry-button:hover,
+.random-entry-button:focus-visible {
+  transform: translate(-1px, -1px);
+  box-shadow: 4px 4px 0 var(--color-shadow);
+  background: var(--color-strong-bg);
+  color: var(--color-strong-text);
+}
+
+.random-entry-button:focus-visible {
+  outline: 2px solid var(--color-border);
+  outline-offset: 2px;
+}
+
+.random-entry-button:active {
+  transform: translate(0, 0);
+  box-shadow: 2px 2px 0 var(--color-shadow);
+}
+
 
 .blog-list {
   display: flex;
@@ -1142,7 +1175,9 @@ details#sources[open] > ol {
 }
 
 .blog-card {
-  display: block;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
   border: 2px solid var(--color-border);
   padding: 1.25rem;
   border-radius: 12px;
@@ -1155,7 +1190,9 @@ details#sources[open] > ol {
 }
 
 .blog-card .blog-tags {
-  margin-top: 1rem;
+  margin-top: auto;
+  padding-top: 1rem;
+  align-self: flex-start;
 }
 
 .blog-card:hover,
@@ -1326,5 +1363,171 @@ details#sources[open] > ol {
 .footer-static .footer-note a[aria-current="page"] {
   font-weight: 600;
   text-decoration: underline;
+}
+
+.awkward-page main {
+  position: relative;
+  padding-bottom: 4rem;
+}
+
+.awkward-page__lead {
+  font-size: clamp(1.2rem, 2.5vw + 1rem, 2rem);
+  line-height: 1.6;
+  max-width: 55ch;
+}
+
+.awkward-page__actions {
+  margin-top: 2rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.awkward-page__actions a {
+  border: 2px solid var(--color-border);
+  background: var(--color-surface);
+  border-radius: 12px;
+  padding: 0.6rem 1.3rem;
+  font-weight: 600;
+  text-decoration: none;
+  color: inherit;
+  box-shadow: 3px 3px 0 var(--color-shadow);
+  transition: transform 0.15s ease, box-shadow 0.15s ease,
+    background 0.15s ease, color 0.15s ease;
+}
+
+.awkward-page__actions a:hover,
+.awkward-page__actions a:focus-visible {
+  transform: translate(-1px, -1px);
+  box-shadow: 4px 4px 0 var(--color-shadow);
+  background: var(--color-strong-bg);
+  color: var(--color-strong-text);
+}
+
+.awkward-page__actions a:focus-visible {
+  outline: 2px solid var(--color-border);
+  outline-offset: 2px;
+}
+
+.awkward-killroy-field {
+  position: relative;
+  margin: 3rem 0;
+  min-height: clamp(320px, 60vh, 640px);
+  border: 2px dashed var(--color-border);
+  border-radius: 24px;
+  overflow: hidden;
+  background: var(--color-panel-muted);
+}
+
+.awkward-killroy {
+  position: absolute;
+  width: 120px;
+  height: 90px;
+  color: hsl(var(--killroy-hue, 12), 80%, 56%);
+  left: var(--killroy-x, 50%);
+  top: var(--killroy-y, 50%);
+  transform: translate(-50%, -50%) scale(var(--killroy-scale, 1))
+    rotate(var(--killroy-rotate, 0deg));
+  opacity: 0.8;
+  pointer-events: none;
+}
+
+.awkward-killroy::before {
+  content: "";
+  position: absolute;
+  width: 74px;
+  height: 44px;
+  border: 4px solid currentColor;
+  border-bottom: none;
+  border-radius: 60px 60px 0 0;
+  left: 50%;
+  top: 0;
+  transform: translateX(-50%);
+}
+
+.awkward-killroy::after {
+  content: "";
+  position: absolute;
+  width: 14px;
+  height: 24px;
+  border-radius: 50% 50% 40% 40%;
+  background: currentColor;
+  left: 50%;
+  top: 36px;
+  transform: translate(-50%, -50%);
+}
+
+.awkward-killroy__eyes {
+  position: absolute;
+  top: 22px;
+  left: 50%;
+  width: 50px;
+  display: flex;
+  justify-content: space-between;
+  transform: translateX(-50%);
+}
+
+.awkward-killroy__eyes::before,
+.awkward-killroy__eyes::after {
+  content: "";
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.awkward-killroy__hands {
+  position: absolute;
+  top: 58px;
+  left: 50%;
+  width: 100px;
+  height: 36px;
+  border: 4px solid currentColor;
+  border-top: none;
+  border-radius: 0 0 18px 18px;
+  transform: translateX(-50%);
+}
+
+.awkward-killroy__hands::before,
+.awkward-killroy__hands::after {
+  content: "";
+  position: absolute;
+  bottom: -6px;
+  width: 20px;
+  height: 20px;
+  border: 4px solid currentColor;
+  border-radius: 50%;
+}
+
+.awkward-killroy__hands::before {
+  left: -4px;
+}
+
+.awkward-killroy__hands::after {
+  right: -4px;
+}
+
+.awkward-killroy__caption {
+  position: absolute;
+  bottom: -1.2rem;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: currentColor;
+  opacity: 0.6;
+}
+
+@media (max-width: 600px) {
+  .awkward-killroy {
+    width: 96px;
+    height: 74px;
+  }
+
+  .awkward-killroy__hands {
+    width: 80px;
+  }
 }
 

--- a/js/blog.js
+++ b/js/blog.js
@@ -9,6 +9,9 @@ const VERSION = (function () {
 })();
 
 // Describe the content sources for each supported section.
+const AWKWARD_SURPRISE_URL = "/pages/easter-egg/awkward.html";
+const AWKWARD_SURPRISE_CHANCE = 1 / 500;
+
 const SECTION_CONFIG = {
   blog: {
     label: "Blog",
@@ -20,6 +23,7 @@ const SECTION_CONFIG = {
     noneMatchMessage: "No posts match the selected tags yet.",
     fallbackDescription: "Notes from the lab bench.",
     schemaType: "BlogPosting",
+    awkwardUrl: AWKWARD_SURPRISE_URL,
   },
   projects: {
     label: "Projects",
@@ -31,6 +35,7 @@ const SECTION_CONFIG = {
     noneMatchMessage: "No projects match the selected tags yet.",
     fallbackDescription: "Hands-on builds and experiments.",
     schemaType: "CreativeWork",
+    awkwardUrl: AWKWARD_SURPRISE_URL,
   },
   research: {
     label: "Research",
@@ -42,6 +47,7 @@ const SECTION_CONFIG = {
     noneMatchMessage: "No research entries match the selected tags yet.",
     fallbackDescription: "Longer-form investigations and papers.",
     schemaType: "ScholarlyArticle",
+    awkwardUrl: AWKWARD_SURPRISE_URL,
   },
 };
 
@@ -635,13 +641,25 @@ async function renderSectionIndex(section, options = {}) {
   const clearBtn = options.clearButtonId
     ? document.getElementById(options.clearButtonId)
     : null;
+  const randomBtn = options.randomButtonId
+    ? document.getElementById(options.randomButtonId)
+    : null;
 
   const { entries: manifestEntries = [], tags: manifestTags = [] } =
     await loadManifest(section);
   const entries = Array.isArray(manifestEntries) ? manifestEntries : [];
   const defaultTags = Array.isArray(manifestTags) ? manifestTags : [];
 
-  const state = { activeTags: new Set() };
+  const state = { activeTags: new Set(), lastRenderedEntries: [] };
+
+  const awkwardUrl =
+    typeof options.awkwardUrl === "string" && options.awkwardUrl
+      ? options.awkwardUrl
+      : config.awkwardUrl || AWKWARD_SURPRISE_URL;
+  const awkwardChance =
+    typeof options.awkwardChance === "number" && options.awkwardChance >= 0
+      ? options.awkwardChance
+      : AWKWARD_SURPRISE_CHANCE;
 
   const sortedEntries = entries
     .slice()
@@ -741,8 +759,34 @@ async function renderSectionIndex(section, options = {}) {
     });
   }
 
+  if (randomBtn) {
+    randomBtn.hidden = false;
+    randomBtn.addEventListener("click", (event) => {
+      event.preventDefault();
+      const pool =
+        state.lastRenderedEntries && state.lastRenderedEntries.length
+          ? state.lastRenderedEntries
+          : enrichedEntries;
+      const showAwkward =
+        pool.length === 0 || Math.random() < Math.min(awkwardChance, 1);
+      if (showAwkward) {
+        window.location.href = awkwardUrl;
+        return;
+      }
+      const choice =
+        pool[Math.floor(Math.random() * Math.max(1, pool.length))];
+      if (!choice || !choice.id) {
+        window.location.href = awkwardUrl;
+        return;
+      }
+      const url = `${config.detailPath}?id=${encodeURIComponent(choice.id)}`;
+      window.location.href = url;
+    });
+  }
+
   function renderList() {
     const filtered = filterEntries();
+    state.lastRenderedEntries = filtered;
     if (!filtered.length) {
       const message = document.createElement("p");
       message.textContent = state.activeTags.size
@@ -935,6 +979,7 @@ export async function renderBlogIndex() {
     filterContainerId: "blog-filter",
     filterTagsId: "blog-filter-tags",
     clearButtonId: "blog-filter-clear",
+    randomButtonId: "blog-random",
   });
 }
 
@@ -951,6 +996,7 @@ export async function renderProjectsIndex() {
     filterContainerId: "projects-filter",
     filterTagsId: "projects-filter-tags",
     clearButtonId: "projects-filter-clear",
+    randomButtonId: "projects-random",
   });
 }
 
@@ -967,6 +1013,7 @@ export async function renderResearchIndex() {
     filterContainerId: "research-filter",
     filterTagsId: "research-filter-tags",
     clearButtonId: "research-filter-clear",
+    randomButtonId: "research-random",
   });
 }
 

--- a/js/site.js
+++ b/js/site.js
@@ -1456,8 +1456,8 @@ const CONTENT_RENDERERS = Object.freeze({
         }
         return mod.renderLatestEntries("blog", {
           rootId: "home-latest-blog",
-          limit: 3,
-          maxItems: 3,
+          limit: 4,
+          maxItems: 4,
           errorMessage: "Latest posts are temporarily unavailable.",
         });
       }),
@@ -1475,8 +1475,8 @@ const CONTENT_RENDERERS = Object.freeze({
         }
         return mod.renderLatestEntries("research", {
           rootId: "home-latest-research",
-          limit: 3,
-          maxItems: 3,
+          limit: 4,
+          maxItems: 4,
           errorMessage: "Latest research highlights are unavailable right now.",
         });
       }),
@@ -1494,8 +1494,8 @@ const CONTENT_RENDERERS = Object.freeze({
         }
         return mod.renderLatestEntries("projects", {
           rootId: "home-latest-projects",
-          limit: 3,
-          maxItems: 3,
+          limit: 4,
+          maxItems: 4,
           errorMessage: "Latest projects are temporarily unavailable.",
         });
       }),

--- a/pages/blog/index.html
+++ b/pages/blog/index.html
@@ -63,6 +63,14 @@
             Clear selected tags
           </button>
         </div>
+        <button
+          type="button"
+          class="random-entry-button"
+          id="blog-random"
+          hidden
+        >
+          Pick a random post
+        </button>
         <noscript>
           <p class="blog-filter-note">
             Filtering posts by tag requires JavaScript. Browse the list below to

--- a/pages/easter-egg/awkward.html
+++ b/pages/easter-egg/awkward.html
@@ -1,0 +1,109 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Oops, This Is Awkward — Braeden Silver</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="We couldn't find something to show you, so enjoy a field of mischievous Kilroys instead."
+    />
+    <meta property="og:title" content="Oops, This Is Awkward — Braeden Silver" />
+    <meta
+      property="og:description"
+      content="A surprise page full of colorful Kilroys when the randomizer runs out of ideas."
+    />
+    <link rel="stylesheet" href="/assets/site.css" />
+  </head>
+  <body class="awkward-page" data-section="awkward">
+    <div id="site-header">
+      <noscript>
+        <div class="noscript-banner" role="alert">
+          JavaScript powers the interactive parts of this site. Please enable it
+          to explore everything on BraedenSilver.com.
+          <a href="/pages/help/enable-javascript/index.html">
+            Learn how to turn on JavaScript.
+          </a>
+        </div>
+      </noscript>
+    </div>
+
+    <main id="main-content">
+      <nav class="page-back" aria-label="Back navigation">
+        <a class="project-entry back-link" href="/index.html">
+          <span class="back-link-icon" aria-hidden="true">←</span>
+          <span class="back-link-label">Take me back home</span>
+        </a>
+      </nav>
+      <h1>Oops, this is awkward.</h1>
+      <p class="awkward-page__lead">
+        The random button blinked, shrugged, and handed you to the Kilroy crew.
+        Refresh the page or try again for a proper entry — unless you're happy
+        to hang out with these doodled lookouts.
+      </p>
+      <div class="awkward-page__actions">
+        <a href="/pages/blog/index.html">Browse the full blog</a>
+        <a href="/pages/projects/index.html">Explore every project</a>
+        <a href="/pages/research/index.html">Inspect all research notes</a>
+      </div>
+      <div
+        class="awkward-killroy-field"
+        id="awkward-killroy-field"
+        aria-hidden="true"
+      ></div>
+    </main>
+
+    <div id="site-footer">
+      <noscript>
+        <div class="noscript-banner" role="alert">
+          JavaScript powers the interactive parts of this site. Please enable it
+          to explore everything on BraedenSilver.com.
+          <a href="/pages/help/enable-javascript/index.html">
+            Learn how to turn on JavaScript.
+          </a>
+        </div>
+      </noscript>
+    </div>
+
+    <script src="/js/site.js" defer></script>
+    <script>
+      (function () {
+        const field = document.getElementById("awkward-killroy-field");
+        if (!field) {
+          return;
+        }
+        const total = 28;
+        const fragment = document.createDocumentFragment();
+        for (let i = 0; i < total; i += 1) {
+          const el = document.createElement("div");
+          el.className = "awkward-killroy";
+          el.innerHTML =
+            '<span class="awkward-killroy__eyes"></span>' +
+            '<span class="awkward-killroy__hands"></span>' +
+            '<span class="awkward-killroy__caption">Kilroy!</span>';
+          fragment.appendChild(el);
+        }
+        field.appendChild(fragment);
+
+        function randomInRange(min, max) {
+          return Math.random() * (max - min) + min;
+        }
+
+        requestAnimationFrame(() => {
+          field.querySelectorAll(".awkward-killroy").forEach((el) => {
+            const hue = Math.floor(Math.random() * 360);
+            const x = randomInRange(10, 90);
+            const y = randomInRange(8, 92);
+            const scale = randomInRange(0.65, 1.6);
+            const rotate = randomInRange(-30, 30);
+            el.style.setProperty("--killroy-hue", hue.toString());
+            el.style.setProperty("--killroy-x", `${x}%`);
+            el.style.setProperty("--killroy-y", `${y}%`);
+            el.style.setProperty("--killroy-scale", scale.toFixed(2));
+            el.style.setProperty("--killroy-rotate", `${rotate.toFixed(1)}deg`);
+          });
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/pages/projects/index.html
+++ b/pages/projects/index.html
@@ -62,6 +62,14 @@
             Clear selected tags
           </button>
         </div>
+        <button
+          type="button"
+          class="random-entry-button"
+          id="projects-random"
+          hidden
+        >
+          Pick a random project
+        </button>
         <noscript>
           <p class="blog-filter-note">
             Filtering projects by tag requires JavaScript. Browse the list below

--- a/pages/research/index.html
+++ b/pages/research/index.html
@@ -62,6 +62,14 @@
             Clear selected tags
           </button>
         </div>
+        <button
+          type="button"
+          class="random-entry-button"
+          id="research-random"
+          hidden
+        >
+          Pick a random research note
+        </button>
         <noscript>
           <p class="blog-filter-note">
             Filtering research entries requires JavaScript. Browse the list


### PR DESCRIPTION
## Summary
- update blog card layout to use a column flexbox so its contents can stretch
- anchor the tag list to the lower-left corner with automatic spacing for consistent placement
- show the four most recent blog, research, and project entries on the home page instead of three
- add random entry buttons to each content index with a 1-in-500 Easter egg redirect
- create the awkward Kilroy page used when no entries exist or the Easter egg triggers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2fd61a97c8330bdf1bdc05942981a