### PR TITLE
Drive announcement marquee with position-based restarts

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -357,7 +357,9 @@ html.theme-dark .theme-toggle__icon--moon {
   display: flex;
   gap: 3rem;
   white-space: nowrap;
-  animation: announcement-scroll 18s linear infinite;
+  will-change: transform;
+  animation: announcement-scroll var(--announcement-duration, 18s) linear
+    infinite;
 }
 
 .announcement-message span {
@@ -1458,7 +1460,7 @@ details#sources[open] > ol {
   height: var(--awkward-size, var(--awkward-size-default));
   transform: translate(-50%, -50%) rotate(var(--killroy-rotate, 0deg));
   pointer-events: none;
-  opacity: 0.94;
+  opacity: 1;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/js/site.js
+++ b/js/site.js
@@ -54,6 +54,7 @@ const FALLBACK_VISITOR_MESSAGE = "Thank you for visiting BraedenSilver.com";
 
 const HOLIDAY_CONFIG_URL = "/data/holiday-banners.json";
 const BANNER_TIME_ZONE = "America/Chicago";
+const ANNOUNCEMENT_SPEED_PX_PER_SECOND = 72;
 
 const MOON_PHASES = Object.freeze([
   { name: "New Moon", emoji: "🌑" },
@@ -1002,6 +1003,198 @@ function prefersReducedMotion() {
   return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 }
 
+const announcementMarqueeRegistry = new Map();
+let announcementMarqueeListenersRegistered = false;
+let announcementMarqueeRefreshHandle = null;
+
+function ensureAnnouncementMarqueeListeners() {
+  if (announcementMarqueeListenersRegistered) return;
+  if (typeof window === "undefined") return;
+
+  announcementMarqueeListenersRegistered = true;
+  window.addEventListener("resize", queueAnnouncementMarqueeRefresh);
+
+  if (typeof window.matchMedia === "function") {
+    try {
+      const query = window.matchMedia("(prefers-reduced-motion: reduce)");
+      const handler = () => queueAnnouncementMarqueeRefresh();
+      if (typeof query.addEventListener === "function") {
+        query.addEventListener("change", handler);
+      } else if (typeof query.addListener === "function") {
+        query.addListener(handler);
+      }
+    } catch {
+      // Ignore unsupported matchMedia usage.
+    }
+  }
+}
+
+function queueAnnouncementMarqueeRefresh() {
+  if (typeof window === "undefined") return;
+  if (announcementMarqueeRefreshHandle != null) return;
+
+  if (typeof window.requestAnimationFrame !== "function") {
+    announcementMarqueeRegistry.forEach((_, track) => {
+      startAnnouncementMarquee(track);
+    });
+    return;
+  }
+
+  announcementMarqueeRefreshHandle = window.requestAnimationFrame(() => {
+    announcementMarqueeRefreshHandle = null;
+    announcementMarqueeRegistry.forEach((_, track) => {
+      startAnnouncementMarquee(track);
+    });
+  });
+}
+
+function registerAnnouncementMarquee(marquee, track) {
+  if (!marquee || !track) return;
+
+  const existing = announcementMarqueeRegistry.get(track);
+  if (existing) {
+    existing.marquee = marquee;
+  } else {
+    announcementMarqueeRegistry.set(track, { marquee, state: null });
+  }
+
+  ensureAnnouncementMarqueeListeners();
+  startAnnouncementMarquee(track);
+}
+
+function stopAnnouncementMarquee(track) {
+  const entry = announcementMarqueeRegistry.get(track);
+  if (!entry) {
+    if (track) {
+      track.style.removeProperty("transform");
+      track.style.removeProperty("animation");
+    }
+    return;
+  }
+
+  const { state } = entry;
+  if (
+    state &&
+    typeof window !== "undefined" &&
+    typeof window.cancelAnimationFrame === "function" &&
+    state.rafId != null
+  ) {
+    window.cancelAnimationFrame(state.rafId);
+  }
+
+  entry.state = null;
+  if (track) {
+    track.style.removeProperty("transform");
+    track.style.removeProperty("animation");
+  }
+}
+
+function unregisterAnnouncementMarquee(track) {
+  stopAnnouncementMarquee(track);
+  announcementMarqueeRegistry.delete(track);
+}
+
+function startAnnouncementMarquee(track) {
+  const entry = announcementMarqueeRegistry.get(track);
+  if (!entry) return;
+
+  const canAnimate =
+    typeof window !== "undefined" &&
+    typeof window.requestAnimationFrame === "function";
+
+  stopAnnouncementMarquee(track);
+
+  const marquee = entry.marquee;
+  if (!marquee || !track || !marquee.isConnected || !track.isConnected) {
+    announcementMarqueeRegistry.delete(track);
+    return;
+  }
+
+  if (!canAnimate) {
+    return;
+  }
+
+  if (prefersReducedMotion()) {
+    track.style.animation = "none";
+    track.style.transform = "";
+    return;
+  }
+
+  const marqueeWidth = marquee.clientWidth;
+  const trackWidth = track.scrollWidth;
+  if (marqueeWidth <= 0 || trackWidth <= 0) {
+    track.style.transform = "";
+    return;
+  }
+
+  const state = {
+    marqueeWidth,
+    trackWidth,
+    position: marqueeWidth,
+    lastTimestamp: null,
+    rafId: null,
+  };
+
+  entry.state = state;
+
+  track.style.animation = "none";
+  track.style.transform = `translateX(${state.position}px)`;
+
+  const step = (timestamp) => {
+    if (entry.state !== state) {
+      return;
+    }
+
+    if (!marquee.isConnected || !track.isConnected) {
+      unregisterAnnouncementMarquee(track);
+      return;
+    }
+
+    if (prefersReducedMotion()) {
+      stopAnnouncementMarquee(track);
+      track.style.animation = "none";
+      track.style.transform = "";
+      return;
+    }
+
+    const measuredMarqueeWidth = marquee.clientWidth;
+    const measuredTrackWidth = track.scrollWidth;
+    if (measuredMarqueeWidth > 0) {
+      state.marqueeWidth = measuredMarqueeWidth;
+    }
+    if (measuredTrackWidth > 0) {
+      state.trackWidth = measuredTrackWidth;
+    }
+
+    if (state.trackWidth <= 0) {
+      stopAnnouncementMarquee(track);
+      return;
+    }
+
+    if (state.position > state.marqueeWidth) {
+      state.position = state.marqueeWidth;
+    }
+
+    if (state.lastTimestamp == null) {
+      state.lastTimestamp = timestamp;
+    } else {
+      const elapsed = timestamp - state.lastTimestamp;
+      state.lastTimestamp = timestamp;
+      const delta = (elapsed / 1000) * ANNOUNCEMENT_SPEED_PX_PER_SECOND;
+      state.position -= delta;
+      if (state.position <= -state.trackWidth) {
+        state.position = state.marqueeWidth;
+        state.lastTimestamp = timestamp;
+      }
+    }
+
+    track.style.transform = `translateX(${state.position}px)`;
+    state.rafId = window.requestAnimationFrame(step);
+  };
+
+  state.rafId = window.requestAnimationFrame(step);
+}
+
 /**
  * Scale the wide ASCII logo so it fits within its container.
  */
@@ -1339,6 +1532,7 @@ function initAnnouncementBanner() {
 
   const text = (banner.dataset.text || "").trim();
   if (!text) {
+    unregisterAnnouncementMarquee(track);
     banner.remove();
     return;
   }
@@ -1359,11 +1553,10 @@ function initAnnouncementBanner() {
     track.appendChild(span);
   }
 
-  // Restart the animation so it begins after the DOM is ready.
-  track.style.animation = "none";
-  // eslint-disable-next-line no-unused-expressions
-  track.offsetHeight;
-  track.style.animation = "";
+  const marquee = banner.querySelector(".announcement-marquee");
+  if (marquee) {
+    registerAnnouncementMarquee(marquee, track);
+  }
 
   const close = banner.querySelector(".announcement-close");
   if (close) {
@@ -1373,6 +1566,7 @@ function initAnnouncementBanner() {
       } catch {
         // Ignore storage failures and fall back to removing for this page load only.
       }
+      unregisterAnnouncementMarquee(track);
       banner.remove();
     });
   }

--- a/pages/easter-egg/awkward.html
+++ b/pages/easter-egg/awkward.html
@@ -98,6 +98,47 @@
             : false;
 
         requestAnimationFrame(() => {
+          const fieldRect = field.getBoundingClientRect();
+          const fieldWidth = Math.max(fieldRect.width, 1);
+          const fieldHeight = Math.max(fieldRect.height, 1);
+          const placements = [];
+          const boundaryPadding = Math.max(
+            12,
+            Math.min(32, Math.min(fieldWidth, fieldHeight) * 0.08)
+          );
+
+          function findPosition(radius, spacing) {
+            const minX = radius + boundaryPadding;
+            const maxX = fieldWidth - radius - boundaryPadding;
+            const minY = radius + boundaryPadding;
+            const maxY = fieldHeight - radius - boundaryPadding;
+
+            if (minX >= maxX || minY >= maxY) {
+              return null;
+            }
+
+            const maxAttempts = 80;
+            for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+              const candidateX = randomInRange(minX, maxX);
+              const candidateY = randomInRange(minY, maxY);
+
+              const hasOverlap = placements.some((placed) => {
+                const dx = placed.x - candidateX;
+                const dy = placed.y - candidateY;
+                const distance = Math.hypot(dx, dy);
+                return distance < placed.radius + radius + spacing;
+              });
+
+              if (!hasOverlap) {
+                return { x: candidateX, y: candidateY };
+              }
+            }
+
+            return null;
+          }
+
+          const spacings = [28, 24, 20, 16, 12, 8];
+
           field.querySelectorAll(".awkward-killroy").forEach((el) => {
             el.style.removeProperty("--awkward-border");
             el.style.removeProperty("--awkward-shadow");
@@ -107,19 +148,27 @@
             const saturation = randomInRange(62, 88);
             const lightness = randomInRange(56, 78);
 
-            const x = randomInRange(12, 88);
-            const y = randomInRange(12, 88);
             const minSize = isCompactViewport ? 102 : 120;
             const maxSize = isCompactViewport ? 148 : 176;
-            const size = randomInRange(minSize, maxSize);
+            const maxDimension = Math.max(
+              0,
+              Math.min(fieldWidth, fieldHeight) - boundaryPadding * 2
+            );
+            const sizeUpperBound =
+              maxDimension > 0
+                ? Math.max(minSize, Math.min(maxSize, maxDimension))
+                : minSize;
+            const initialLowerBound = Math.min(minSize, sizeUpperBound);
+            let size = randomInRange(initialLowerBound, sizeUpperBound);
             const rotate = randomInRange(-7, 7);
+            const eyeOffsetFactor = randomInRange(0.19, 0.22);
+            const eyeTopFactor = randomInRange(0.32, 0.36);
+            const eyeSizeFactor = randomInRange(0.22, 0.25);
 
-            const eyeOffset = Math.round(size * randomInRange(0.19, 0.22));
-            const eyeTop = Math.round(size * randomInRange(0.32, 0.36));
-            const eyeSize = Math.round(size * randomInRange(0.22, 0.25));
-            const eyeBorder = Math.min(4, Math.max(2, Math.round(size * 0.018)));
-            const borderWidth = Math.min(3, Math.max(2, Math.round(size * 0.016)));
-            const shadowOffset = Math.min(8, Math.max(4, Math.round(size * 0.035)));
+            const absoluteMinSize = Math.min(
+              sizeUpperBound,
+              Math.max(72, minSize * 0.75)
+            );
 
             const scleraLightness = Math.min(97, lightness + randomInRange(24, 32));
             const scleraColor = toHsl(
@@ -128,12 +177,52 @@
               scleraLightness
             );
 
+            const radius = () => size / 2;
+            let position = null;
+
+            for (const spacing of spacings) {
+              position = findPosition(radius(), spacing);
+              if (position) {
+                break;
+              }
+              if (size > absoluteMinSize) {
+                size = Math.max(absoluteMinSize, size * 0.92);
+              }
+            }
+
+            if (!position) {
+              position = findPosition(radius(), 0);
+            }
+
+            if (!position && size > absoluteMinSize) {
+              size = absoluteMinSize;
+              position = findPosition(radius(), 0);
+            }
+
+            if (!position) {
+              position = { x: fieldWidth / 2, y: fieldHeight / 2 };
+            }
+
+            const finalSize = size;
+            const eyeOffset = Math.round(finalSize * eyeOffsetFactor);
+            const eyeTop = Math.round(finalSize * eyeTopFactor);
+            const eyeSize = Math.round(finalSize * eyeSizeFactor);
+            const eyeBorder = Math.min(4, Math.max(2, Math.round(finalSize * 0.018)));
+            const borderWidth = Math.min(3, Math.max(2, Math.round(finalSize * 0.016)));
+            const shadowOffset = Math.min(8, Math.max(4, Math.round(finalSize * 0.035)));
+
+            const finalRadius = finalSize / 2;
+            placements.push({ x: position.x, y: position.y, radius: finalRadius });
+
+            const xPercent = (position.x / fieldWidth) * 100;
+            const yPercent = (position.y / fieldHeight) * 100;
+
             el.style.setProperty("--awkward-skin", toHsl(hue, saturation, lightness));
             el.style.setProperty("--awkward-sclera", scleraColor);
-            el.style.setProperty("--killroy-x", `${x.toFixed(2)}%`);
-            el.style.setProperty("--killroy-y", `${y.toFixed(2)}%`);
+            el.style.setProperty("--killroy-x", `${xPercent.toFixed(2)}%`);
+            el.style.setProperty("--killroy-y", `${yPercent.toFixed(2)}%`);
             el.style.setProperty("--killroy-rotate", `${rotate.toFixed(1)}deg`);
-            el.style.setProperty("--awkward-size", `${size.toFixed(0)}px`);
+            el.style.setProperty("--awkward-size", `${finalSize.toFixed(0)}px`);
             el.style.setProperty("--eye-offset", `${eyeOffset}px`);
             el.style.setProperty("--eye-top", `${eyeTop}px`);
             el.style.setProperty("--eye-size", `${eyeSize}px`);


### PR DESCRIPTION
## Summary
- replace the announcement marquee duration logic with a JavaScript runner that restarts once the message fully clears the viewport
- refresh marquee measurements on resize or reduced-motion preference changes so the scroll distance stays accurate
- add a CSS hint to optimize transform-based scrolling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3235376088330861160125fe27e82