### PR TITLE
Enlarge awkward Kilroy field and scale pupils

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -1414,7 +1414,7 @@ details#sources[open] > ol {
 .awkward-killroy-field {
   position: relative;
   margin: 3rem 0;
-  min-height: clamp(320px, 60vh, 640px);
+  min-height: clamp(520px, 75vh, 960px);
   border: 2px dashed var(--color-border);
   border-radius: 24px;
   overflow: hidden;
@@ -1428,11 +1428,7 @@ details#sources[open] > ol {
     calc(var(--awkward-size-default) * 0.24),
     40px
   );
-  --awkward-eye-border-default: clamp(
-    2px,
-    calc(var(--awkward-size-default) * 0.018),
-    4px
-  );
+  --awkward-eye-border-default: 2.5px;
   --awkward-eye-offset-default: clamp(
     22px,
     calc(var(--awkward-size-default) * 0.21),
@@ -1443,11 +1439,7 @@ details#sources[open] > ol {
     calc(var(--awkward-size-default) * 0.35),
     60px
   );
-  --awkward-border-width-default: clamp(
-    2px,
-    calc(var(--awkward-size-default) * 0.016),
-    3px
-  );
+  --awkward-border-width-default: 2.5px;
   --awkward-shadow-offset-default: clamp(
     4px,
     calc(var(--awkward-size-default) * 0.035),
@@ -1500,6 +1492,14 @@ details#sources[open] > ol {
 }
 
 .awkward-killroy .pupil {
+  width: var(
+    --pupil-size,
+    calc(var(--eye-size, var(--awkward-eye-size-default)) * 0.4286)
+  );
+  height: var(
+    --pupil-size,
+    calc(var(--eye-size, var(--awkward-eye-size-default)) * 0.4286)
+  );
   background: var(--awkward-pupil, var(--color-kilroy-pupil));
 }
 

--- a/pages/easter-egg/awkward.html
+++ b/pages/easter-egg/awkward.html
@@ -138,11 +138,13 @@
           }
 
           const spacings = [28, 24, 20, 16, 12, 8];
+          const FOOTER_PUPIL_RATIO = 12 / 28;
 
           field.querySelectorAll(".awkward-killroy").forEach((el) => {
             el.style.removeProperty("--awkward-border");
             el.style.removeProperty("--awkward-shadow");
             el.style.removeProperty("--awkward-pupil");
+            el.style.removeProperty("--pupil-size");
 
             const hue = randomInRange(0, 360);
             const saturation = randomInRange(62, 88);
@@ -168,13 +170,6 @@
             const absoluteMinSize = Math.min(
               sizeUpperBound,
               Math.max(72, minSize * 0.75)
-            );
-
-            const scleraLightness = Math.min(97, lightness + randomInRange(24, 32));
-            const scleraColor = toHsl(
-              hue,
-              Math.max(6, saturation - 46),
-              scleraLightness
             );
 
             const radius = () => size / 2;
@@ -207,8 +202,8 @@
             const eyeOffset = Math.round(finalSize * eyeOffsetFactor);
             const eyeTop = Math.round(finalSize * eyeTopFactor);
             const eyeSize = Math.round(finalSize * eyeSizeFactor);
-            const eyeBorder = Math.min(4, Math.max(2, Math.round(finalSize * 0.018)));
-            const borderWidth = Math.min(3, Math.max(2, Math.round(finalSize * 0.016)));
+            const pupilSize = Math.round(eyeSize * FOOTER_PUPIL_RATIO);
+            const outlineWidth = 2.5;
             const shadowOffset = Math.min(8, Math.max(4, Math.round(finalSize * 0.035)));
 
             const finalRadius = finalSize / 2;
@@ -218,7 +213,7 @@
             const yPercent = (position.y / fieldHeight) * 100;
 
             el.style.setProperty("--awkward-skin", toHsl(hue, saturation, lightness));
-            el.style.setProperty("--awkward-sclera", scleraColor);
+            el.style.setProperty("--awkward-sclera", "#fff");
             el.style.setProperty("--killroy-x", `${xPercent.toFixed(2)}%`);
             el.style.setProperty("--killroy-y", `${yPercent.toFixed(2)}%`);
             el.style.setProperty("--killroy-rotate", `${rotate.toFixed(1)}deg`);
@@ -226,8 +221,9 @@
             el.style.setProperty("--eye-offset", `${eyeOffset}px`);
             el.style.setProperty("--eye-top", `${eyeTop}px`);
             el.style.setProperty("--eye-size", `${eyeSize}px`);
-            el.style.setProperty("--eye-border", `${eyeBorder}px`);
-            el.style.setProperty("--awkward-border-width", `${borderWidth}px`);
+            el.style.setProperty("--pupil-size", `${pupilSize}px`);
+            el.style.setProperty("--eye-border", `${outlineWidth}px`);
+            el.style.setProperty("--awkward-border-width", `${outlineWidth}px`);
             el.style.setProperty("--awkward-shadow-offset", `${shadowOffset}px`);
           });
         });


### PR DESCRIPTION
## Summary
- enlarge the awkward Kilroy field so the characters have more vertical space to populate
- scale each generated awkward Kilroy pupil in proportion to its eye size using the footer ratio
- provide CSS fallbacks so pupil size remains proportional even without inline styles

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3386864b083309731b7e014a4ad17