### PR TITLE
Restore Konami easter egg overlay

### DIFF
--- a/js/site.js
+++ b/js/site.js
@@ -1,6 +1,8 @@
 // site.js — handles shared layout injection, "last updated" stamps,
 // and small UI effects used throughout the site.
 
+const EASTER_EGG_GROUP = "easter-egg";
+
 const SITE_CONTENT = Object.freeze({
   navItems: [
     {
@@ -42,10 +44,15 @@ const SITE_CONTENT = Object.freeze({
       label: "Contact",
       groups: ["primary"],
     },
+    {
+      href: "/pages/easter-eggs/joejoejoe/index.html",
+      section: "joejoejoe",
+      label: "Joejoejoe Playground",
+      description: "Spin up randomized Joejoe mascots.",
+      groups: [EASTER_EGG_GROUP],
+    },
   ],
 });
-
-const EASTER_EGG_GROUP = "easter-egg";
 
 function getEasterEggPages() {
   return SITE_CONTENT.navItems.filter((item) =>


### PR DESCRIPTION
## Summary
- add the Joejoejoe Playground entry to the site navigation metadata under the easter egg group so the overlay has destinations again
- define the easter egg group constant before the navigation data so the page loads without reference errors

## Testing
- Manual Konami code check on http://localhost:8000/index.html

------
https://chatgpt.com/codex/tasks/task_e_68e418ad60b4833099570757a6f96825