### PR TITLE
Prioritize critical assets and lazy embeds

### DIFF
--- a/404.html
+++ b/404.html
@@ -13,7 +13,19 @@
       property="og:description"
       content="404 error page for Braeden Silver's site"
     />
-    <link rel="stylesheet" href="/assets/site.css" />
+    <link
+      rel="preload"
+      href="/assets/site.css"
+      as="style"
+      fetchpriority="high"
+    />
+    <link rel="stylesheet" href="/assets/site.css" fetchpriority="high" />
+    <link
+      rel="preload"
+      href="/js/site.js"
+      as="script"
+      fetchpriority="high"
+    />
   </head>
   <body>
     <!-- ===== Shared layout containers (populated by js/site.js) ===== -->

--- a/assets/site.css
+++ b/assets/site.css
@@ -492,6 +492,14 @@ html.theme-dark .theme-toggle__icon--moon {
   align-items: stretch;
 }
 
+.home-section__list,
+.blog-list,
+.projects-static-fallback__grid,
+.guestbook-fallback__list {
+  content-visibility: auto;
+  contain-intrinsic-size: 480px;
+}
+
 .home-section__list > p {
   margin: 0;
 }
@@ -1138,6 +1146,70 @@ details#sources[open] > ol {
 .blog-summary {
   margin: 0 0 0.75rem;
   line-height: 1.6;
+}
+
+.lazy-embed-placeholder {
+  margin: 2rem 0;
+  padding: 1.5rem;
+  border: 2px dashed var(--color-border);
+  border-radius: 12px;
+  background: var(--color-panel-muted);
+  box-shadow: 4px 4px 0 var(--color-shadow);
+  display: grid;
+  gap: 0.75rem;
+  max-width: min(480px, 100%);
+}
+
+.lazy-embed-placeholder p {
+  margin: 0;
+}
+
+[data-lazy-embed-status].is-error {
+  color: var(--color-error-text);
+}
+
+.lazy-embed-button {
+  appearance: none;
+  border: 2px solid var(--color-border);
+  background: var(--color-surface);
+  color: inherit;
+  font: inherit;
+  padding: 0.5rem 1.1rem;
+  border-radius: 999px;
+  cursor: pointer;
+  box-shadow: 3px 3px 0 var(--color-shadow);
+  transition: transform 0.15s ease, box-shadow 0.15s ease,
+    background 0.15s ease, color 0.15s ease;
+}
+
+.lazy-embed-button:hover,
+.lazy-embed-button:focus-visible {
+  transform: translate(-1px, -1px);
+  box-shadow: 4px 4px 0 var(--color-shadow);
+  background: var(--color-strong-bg);
+  color: var(--color-strong-text);
+}
+
+.lazy-embed-button:focus-visible {
+  outline: 2px solid var(--color-border);
+  outline-offset: 2px;
+}
+
+.lazy-embed-button:disabled {
+  cursor: wait;
+  opacity: 0.75;
+}
+
+.guestbook-thread.is-loading .lazy-embed-button {
+  cursor: wait;
+}
+
+.guestbook-thread.is-loading .lazy-embed-button:hover,
+.guestbook-thread.is-loading .lazy-embed-button:focus-visible {
+  transform: none;
+  box-shadow: 3px 3px 0 var(--color-shadow);
+  background: var(--color-surface);
+  color: inherit;
 }
 
 .guestbook-fallback {

--- a/index.html
+++ b/index.html
@@ -2,7 +2,19 @@
 <html lang="en">
   <head>
     <link rel="icon" href="/favicon.ico" type="image/x-icon" />
-    <link rel="stylesheet" href="/assets/site.css" />
+    <link
+      rel="preload"
+      href="/assets/site.css"
+      as="style"
+      fetchpriority="high"
+    />
+    <link rel="stylesheet" href="/assets/site.css" fetchpriority="high" />
+    <link
+      rel="preload"
+      href="/js/site.js"
+      as="script"
+      fetchpriority="high"
+    />
     <meta charset="utf-8" />
     <title>
       Braeden Silver | Electrical & Computer Engineering Projects and Bio

--- a/js/blog.js
+++ b/js/blog.js
@@ -553,6 +553,7 @@ function renderBody(blocks) {
         img.alt = block.alt || "";
         img.loading = "lazy";
         img.decoding = "async";
+        img.fetchPriority = "low";
         figure.appendChild(img);
         if (block.caption) {
           const caption = document.createElement("figcaption");
@@ -933,8 +934,9 @@ async function renderSectionEntry(section, options = {}) {
           ? working.heroAlt
           : "";
     img.alt = heroAlt;
-    img.loading = "lazy";
+    img.loading = "eager";
     img.decoding = "async";
+    img.fetchPriority = "high";
     figure.appendChild(img);
     const caption = working.hero_caption || working.heroCaption;
     if (typeof caption === "string" && caption.trim()) {

--- a/js/site-bootstrap.js
+++ b/js/site-bootstrap.js
@@ -1,99 +1,53 @@
 (function initSiteBootstrap() {
-  if (typeof window === "undefined" || typeof document === "undefined") {
+  if (typeof document === "undefined") {
     return;
   }
 
-  const docEl = document.documentElement;
-  if (docEl && !docEl.classList.contains("js-enabled")) {
-    docEl.classList.add("js-enabled");
-  }
-
   const SCRIPT_URL = "/js/site.js";
-  const FALLBACK_DELAY_MS = 3000;
-  const RETRY_DELAY_MS = 1500;
-  const triggerEvents = ["pointerdown", "keydown", "visibilitychange", "focusin"];
 
-  let loadRequested = false;
-  let idleHandle = null;
-  let fallbackTimer = null;
-  let retryTimer = null;
-
-  const cleanup = () => {
-    triggerEvents.forEach((event) =>
-      document.removeEventListener(event, handleTrigger, true),
-    );
-    if (idleHandle !== null && typeof window.cancelIdleCallback === "function") {
-      window.cancelIdleCallback(idleHandle);
-    }
-    if (fallbackTimer !== null) {
-      window.clearTimeout(fallbackTimer);
-    }
-    idleHandle = null;
-    fallbackTimer = null;
-  };
-
-  const resetForRetry = () => {
-    loadRequested = false;
-    if (retryTimer !== null) {
-      window.clearTimeout(retryTimer);
-    }
-    retryTimer = window.setTimeout(requestSiteLoad, RETRY_DELAY_MS);
-  };
-
-  const requestSiteLoad = () => {
-    if (loadRequested) {
+  const ensurePreload = () => {
+    if (!document.head) {
       return;
     }
-    loadRequested = true;
+    const existingPreload = document.head.querySelector(
+      `link[rel="preload"][as="script"][href="${SCRIPT_URL}"]`,
+    );
+    if (existingPreload) {
+      return;
+    }
+    const preload = document.createElement("link");
+    preload.rel = "preload";
+    preload.as = "script";
+    preload.href = SCRIPT_URL;
+    preload.fetchPriority = "high";
+    preload.setAttribute("fetchpriority", "high");
+    document.head.appendChild(preload);
+  };
+
+  const ensureSiteScript = () => {
+    const existingScript = document.querySelector(
+      `script[src="${SCRIPT_URL}"]`,
+    );
+    if (existingScript) {
+      if (!existingScript.hasAttribute("defer")) {
+        existingScript.defer = true;
+      }
+      existingScript.fetchPriority = "high";
+      existingScript.setAttribute("fetchpriority", "high");
+      return;
+    }
 
     const script = document.createElement("script");
     script.src = SCRIPT_URL;
-    script.async = true;
-    script.dataset.lazy = "true";
-
-    script.addEventListener("load", () => {
-      cleanup();
-      if (retryTimer !== null) {
-        window.clearTimeout(retryTimer);
-        retryTimer = null;
-      }
-    });
-
-    script.addEventListener("error", () => {
-      if (script.parentNode) {
-        script.parentNode.removeChild(script);
-      }
-      resetForRetry();
-    });
-
-    (document.head || document.body || document.documentElement).appendChild(
+    script.defer = true;
+    script.fetchPriority = "high";
+    script.setAttribute("fetchpriority", "high");
+    script.dataset.siteEntrypoint = "true";
+    (document.head || document.documentElement || document.body).appendChild(
       script,
     );
   };
 
-  function handleTrigger(event) {
-    if (event.type === "visibilitychange" && document.visibilityState !== "visible") {
-      return;
-    }
-    requestSiteLoad();
-  }
-
-  triggerEvents.forEach((event) =>
-    document.addEventListener(event, handleTrigger, {
-      capture: true,
-      passive: true,
-    }),
-  );
-
-  if (typeof window.requestIdleCallback === "function") {
-    idleHandle = window.requestIdleCallback(
-      () => {
-        idleHandle = null;
-        requestSiteLoad();
-      },
-      { timeout: FALLBACK_DELAY_MS },
-    );
-  } else {
-    fallbackTimer = window.setTimeout(requestSiteLoad, FALLBACK_DELAY_MS);
-  }
+  ensurePreload();
+  ensureSiteScript();
 })();

--- a/js/site.js
+++ b/js/site.js
@@ -826,8 +826,10 @@ function renderQuickLinks(rootId = "home-quick-links") {
               alt=""
               class="arrow"
               aria-hidden="true"
-              loading="lazy"
               decoding="async"
+              width="60"
+              height="40"
+              fetchpriority="low"
             />
             <span class="quick-link-content">
               <span class="quick-link-label">${escapeHtml(item.label)}</span>
@@ -838,8 +840,10 @@ function renderQuickLinks(rootId = "home-quick-links") {
               alt=""
               class="arrow"
               aria-hidden="true"
-              loading="lazy"
               decoding="async"
+              width="60"
+              height="40"
+              fetchpriority="low"
             />
           </a>
         </li>`;
@@ -2116,6 +2120,151 @@ function initShareLink() {
   });
 }
 
+const GISCUS_DATA_MAPPINGS = Object.freeze([
+  ["giscusRepo", "repo"],
+  ["giscusRepoId", "repo-id"],
+  ["giscusCategory", "category"],
+  ["giscusCategoryId", "category-id"],
+  ["giscusMapping", "mapping"],
+  ["giscusStrict", "strict"],
+  ["giscusReactionsEnabled", "reactions-enabled"],
+  ["giscusEmitMetadata", "emit-metadata"],
+  ["giscusInputPosition", "input-position"],
+  ["giscusTheme", "theme"],
+  ["giscusLang", "lang"],
+]);
+
+function updateLazyEmbedStatus(container, message, isError = false) {
+  const status = container?.querySelector("[data-lazy-embed-status]");
+  if (status) {
+    status.textContent = message;
+    status.classList.toggle("is-error", Boolean(isError && message));
+  }
+}
+
+function setLazyEmbedLoadingState(container, isLoading) {
+  if (!container) return;
+  container.classList.toggle("is-loading", Boolean(isLoading));
+  if (isLoading) {
+    container.setAttribute("aria-busy", "true");
+  } else {
+    container.removeAttribute("aria-busy");
+  }
+}
+
+function loadGiscusEmbed(container) {
+  if (!container) return;
+  const state = container.dataset.lazyEmbedLoaded;
+  if (state === "pending" || state === "true") {
+    return;
+  }
+
+  container.dataset.lazyEmbedLoaded = "pending";
+  setLazyEmbedLoadingState(container, true);
+  updateLazyEmbedStatus(container, "Loading guest book…");
+
+  const trigger = container.querySelector("[data-lazy-embed-trigger]");
+  if (trigger) {
+    trigger.disabled = true;
+  }
+
+  const script = document.createElement("script");
+  script.src = container.dataset.giscusSrc || "https://giscus.app/client.js";
+  script.async = true;
+  const crossOrigin = container.dataset.giscusCrossorigin || "anonymous";
+  script.crossOrigin = crossOrigin;
+
+  GISCUS_DATA_MAPPINGS.forEach(([dataKey, attrName]) => {
+    const value = container.dataset[dataKey];
+    if (value !== undefined) {
+      script.setAttribute(`data-${attrName}`, value);
+    }
+  });
+
+  script.addEventListener("load", () => {
+    container.dataset.lazyEmbedLoaded = "true";
+    setLazyEmbedLoadingState(container, false);
+    const placeholder = container.querySelector("[data-lazy-embed-placeholder]");
+    placeholder?.remove();
+  });
+
+  script.addEventListener("error", () => {
+    delete container.dataset.lazyEmbedLoaded;
+    setLazyEmbedLoadingState(container, false);
+    updateLazyEmbedStatus(
+      container,
+      "Guest book failed to load. Try again?",
+      true,
+    );
+    if (trigger) {
+      trigger.disabled = false;
+      try {
+        trigger.focus({ preventScroll: true });
+      } catch {
+        trigger.focus();
+      }
+    }
+    script.remove();
+  });
+
+  container.appendChild(script);
+}
+
+function loadLazyEmbed(container) {
+  if (!container) return;
+  const type = container.dataset.lazyEmbed;
+  if (!type) return;
+  if (type === "giscus") {
+    loadGiscusEmbed(container);
+  }
+}
+
+function initLazyEmbeds() {
+  if (typeof document === "undefined") return;
+  const containers = document.querySelectorAll("[data-lazy-embed]");
+  if (!containers.length) return;
+
+  const handleTrigger = (event) => {
+    const container = event.currentTarget?.closest("[data-lazy-embed]");
+    if (!container) return;
+    event.preventDefault();
+    loadLazyEmbed(container);
+  };
+
+  containers.forEach((container) => {
+    const trigger = container.querySelector("[data-lazy-embed-trigger]");
+    if (trigger) {
+      trigger.addEventListener("click", handleTrigger);
+      trigger.addEventListener("keydown", (event) => {
+        if (event.key === "Enter" || event.key === " " || event.key === "Spacebar") {
+          event.preventDefault();
+          loadLazyEmbed(container);
+        }
+      });
+    }
+  });
+
+  if (typeof window !== "undefined" && "IntersectionObserver" in window) {
+    const observer = new IntersectionObserver(
+      (entries, obs) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            obs.unobserve(entry.target);
+            loadLazyEmbed(entry.target);
+          }
+        });
+      },
+      { rootMargin: "200px 0px" },
+    );
+    containers.forEach((container) => observer.observe(container));
+    return;
+  }
+
+  window.setTimeout(() => {
+    containers.forEach((container) => loadLazyEmbed(container));
+  }, 1200);
+}
+
 // Map each data-content-render token to its associated loader and fallback handler.
 const CONTENT_RENDERERS = Object.freeze({
   "blog:index": {
@@ -2331,6 +2480,7 @@ async function initializeSite() {
   initThemeToggle();
   initHistoryBackLinks();
   initShareLink();
+  initLazyEmbeds();
   initKonamiCode();
 
   await Promise.all([

--- a/pages/about/index.html
+++ b/pages/about/index.html
@@ -13,7 +13,19 @@
       property="og:description"
       content="Read a handful of personal highlights that paint a fuller picture of Braeden Silver."
     />
-    <link rel="stylesheet" href="/assets/site.css" />
+    <link
+      rel="preload"
+      href="/assets/site.css"
+      as="style"
+      fetchpriority="high"
+    />
+    <link rel="stylesheet" href="/assets/site.css" fetchpriority="high" />
+    <link
+      rel="preload"
+      href="/js/site.js"
+      as="script"
+      fetchpriority="high"
+    />
   </head>
   <body data-section="about">
     <!-- ===== Shared layout containers (populated by js/site.js) ===== -->

--- a/pages/blog/index.html
+++ b/pages/blog/index.html
@@ -13,7 +13,19 @@
       property="og:description"
       content="A quietly updated log of things I build, fix, and learn."
     />
-    <link rel="stylesheet" href="/assets/site.css" />
+    <link
+      rel="preload"
+      href="/assets/site.css"
+      as="style"
+      fetchpriority="high"
+    />
+    <link rel="stylesheet" href="/assets/site.css" fetchpriority="high" />
+    <link
+      rel="preload"
+      href="/js/site.js"
+      as="script"
+      fetchpriority="high"
+    />
   </head>
   <body data-section="blog" data-content-render="blog:index">
     <!-- ===== Shared layout containers (populated by js/site.js) ===== -->

--- a/pages/blog/post.html
+++ b/pages/blog/post.html
@@ -13,7 +13,19 @@
       property="og:description"
       content="Blog post on Braeden Silver's personal site."
     />
-    <link rel="stylesheet" href="/assets/site.css" />
+    <link
+      rel="preload"
+      href="/assets/site.css"
+      as="style"
+      fetchpriority="high"
+    />
+    <link rel="stylesheet" href="/assets/site.css" fetchpriority="high" />
+    <link
+      rel="preload"
+      href="/js/site.js"
+      as="script"
+      fetchpriority="high"
+    />
   </head>
   <body data-section="blog" data-content-render="blog:entry">
     <!-- ===== Shared layout containers (populated by js/site.js) ===== -->

--- a/pages/contact.html
+++ b/pages/contact.html
@@ -13,7 +13,19 @@
       property="og:description"
       content="Contact information for Braeden Silver including email and social links"
     />
-    <link rel="stylesheet" href="/assets/site.css" />
+    <link
+      rel="preload"
+      href="/assets/site.css"
+      as="style"
+      fetchpriority="high"
+    />
+    <link rel="stylesheet" href="/assets/site.css" fetchpriority="high" />
+    <link
+      rel="preload"
+      href="/js/site.js"
+      as="script"
+      fetchpriority="high"
+    />
   </head>
   <body data-section="contact">
     <!-- ===== Shared layout containers (populated by js/site.js) ===== -->
@@ -64,8 +76,11 @@
         <img
           src="/assets/qr-braedensilver.svg"
           alt="QR code linking to braedensilver.com"
-          loading="lazy"
           decoding="async"
+          width="200"
+          height="200"
+          fetchpriority="high"
+          loading="eager"
         />
         <figcaption>Scan to open braedensilver.com on your phone.</figcaption>
       </figure>

--- a/pages/easter-eggs/joejoejoe/index.html
+++ b/pages/easter-eggs/joejoejoe/index.html
@@ -14,7 +14,25 @@
       content="Spin up randomized Joejoejoe mascots, remix their colors, and grab a quick screenshot to share."
     />
     <link rel="icon" href="/favicon.ico" type="image/x-icon" />
-    <link rel="stylesheet" href="/assets/site.css" />
+    <link
+      rel="preload"
+      href="/assets/site.css"
+      as="style"
+      fetchpriority="high"
+    />
+    <link rel="stylesheet" href="/assets/site.css" fetchpriority="high" />
+    <link
+      rel="preload"
+      href="/js/site.js"
+      as="script"
+      fetchpriority="high"
+    />
+    <link
+      rel="preload"
+      href="/assets/joejoejoe.css"
+      as="style"
+      fetchpriority="high"
+    />
     <link rel="stylesheet" href="/assets/joejoejoe.css" />
   </head>
   <body class="joejoe-page joejoejoe-page" data-section="joejoejoe">
@@ -244,6 +262,8 @@
       integrity="sha512-BNaRQnYJYiPSqHHDb58B0yaPfCu+Wgds8Gp/gU33kqBtgNS4tSPHuGibyoeqMV/TJlSKda6FXzoEyYGjTe+vXA=="
       crossorigin="anonymous"
       referrerpolicy="no-referrer"
+      defer
+      fetchpriority="low"
     ></script>
     <script src="/js/site-bootstrap.js" defer></script>
     <script src="/js/joejoejoe.js" defer></script>

--- a/pages/guest-book.html
+++ b/pages/guest-book.html
@@ -13,7 +13,19 @@
       property="og:description"
       content="Sign the guest book to share how you found Braeden Silver or leave a friendly note."
     />
-    <link rel="stylesheet" href="/assets/site.css" />
+    <link
+      rel="preload"
+      href="/assets/site.css"
+      as="style"
+      fetchpriority="high"
+    />
+    <link rel="stylesheet" href="/assets/site.css" fetchpriority="high" />
+    <link
+      rel="preload"
+      href="/js/site.js"
+      as="script"
+      fetchpriority="high"
+    />
   </head>
   <body data-section="guest-book">
     <!-- ===== Shared layout containers (populated by js/site.js) ===== -->
@@ -94,23 +106,37 @@
         <h2 id="guestbook-heading" class="visually-hidden">
           Guest book messages
         </h2>
-        <div class="guestbook-thread" data-nosnippet>
-          <script
-            src="https://giscus.app/client.js"
-            data-repo="BraedenSilver/BraedenSilver.github.io"
-            data-repo-id="R_kgDOM1hCqg"
-            data-category="General"
-            data-category-id="DIC_kwDOM1hCqs4CwPl_"
-            data-mapping="pathname"
-            data-strict="0"
-            data-reactions-enabled="1"
-            data-emit-metadata="0"
-            data-input-position="bottom"
-            data-theme="preferred_color_scheme"
-            data-lang="en"
-            crossorigin="anonymous"
-            async
-          ></script>
+        <div
+          class="guestbook-thread"
+          data-nosnippet
+          data-lazy-embed="giscus"
+          data-giscus-src="https://giscus.app/client.js"
+          data-giscus-repo="BraedenSilver/BraedenSilver.github.io"
+          data-giscus-repo-id="R_kgDOM1hCqg"
+          data-giscus-category="General"
+          data-giscus-category-id="DIC_kwDOM1hCqs4CwPl_"
+          data-giscus-mapping="pathname"
+          data-giscus-strict="0"
+          data-giscus-reactions-enabled="1"
+          data-giscus-emit-metadata="0"
+          data-giscus-input-position="bottom"
+          data-giscus-theme="preferred_color_scheme"
+          data-giscus-lang="en"
+          data-giscus-crossorigin="anonymous"
+        >
+          <div class="lazy-embed-placeholder" data-lazy-embed-placeholder>
+            <p data-lazy-embed-status role="status" aria-live="polite">
+              Guest book comments load after you scroll here to keep the page
+              speedy.
+            </p>
+            <button
+              type="button"
+              class="lazy-embed-button"
+              data-lazy-embed-trigger
+            >
+              Load guest book now
+            </button>
+          </div>
           <noscript>
             <p>Enable JavaScript to view and sign the guest book via Giscus.</p>
           </noscript>

--- a/pages/help/enable-javascript/index.html
+++ b/pages/help/enable-javascript/index.html
@@ -13,7 +13,19 @@
       property="og:description"
       content="Step-by-step instructions for enabling JavaScript and clearing your browser cache."
     />
-    <link rel="stylesheet" href="/assets/site.css" />
+    <link
+      rel="preload"
+      href="/assets/site.css"
+      as="style"
+      fetchpriority="high"
+    />
+    <link rel="stylesheet" href="/assets/site.css" fetchpriority="high" />
+    <link
+      rel="preload"
+      href="/js/site.js"
+      as="script"
+      fetchpriority="high"
+    />
   </head>
   <body>
     <!-- ===== Shared layout containers (populated by js/site.js) ===== -->

--- a/pages/projects/entry.html
+++ b/pages/projects/entry.html
@@ -10,7 +10,19 @@
       property="og:description"
       content="Project details from Braeden Silver."
     />
-    <link rel="stylesheet" href="/assets/site.css" />
+    <link
+      rel="preload"
+      href="/assets/site.css"
+      as="style"
+      fetchpriority="high"
+    />
+    <link rel="stylesheet" href="/assets/site.css" fetchpriority="high" />
+    <link
+      rel="preload"
+      href="/js/site.js"
+      as="script"
+      fetchpriority="high"
+    />
   </head>
   <body data-section="projects" data-content-render="projects:entry">
     <!-- ===== Shared layout containers (populated by js/site.js) ===== -->

--- a/pages/projects/index.html
+++ b/pages/projects/index.html
@@ -13,7 +13,19 @@
       property="og:description"
       content="Personal builds and experiments by Braeden Silver."
     />
-    <link rel="stylesheet" href="/assets/site.css" />
+    <link
+      rel="preload"
+      href="/assets/site.css"
+      as="style"
+      fetchpriority="high"
+    />
+    <link rel="stylesheet" href="/assets/site.css" fetchpriority="high" />
+    <link
+      rel="preload"
+      href="/js/site.js"
+      as="script"
+      fetchpriority="high"
+    />
   </head>
   <body data-section="projects" data-content-render="projects:index">
     <!-- ===== Shared layout containers (populated by js/site.js) ===== -->

--- a/pages/research/entry.html
+++ b/pages/research/entry.html
@@ -10,7 +10,19 @@
       property="og:description"
       content="Research entry from Braeden Silver."
     />
-    <link rel="stylesheet" href="/assets/site.css" />
+    <link
+      rel="preload"
+      href="/assets/site.css"
+      as="style"
+      fetchpriority="high"
+    />
+    <link rel="stylesheet" href="/assets/site.css" fetchpriority="high" />
+    <link
+      rel="preload"
+      href="/js/site.js"
+      as="script"
+      fetchpriority="high"
+    />
   </head>
   <body data-section="research" data-content-render="research:entry">
     <!-- ===== Shared layout containers (populated by js/site.js) ===== -->

--- a/pages/research/index.html
+++ b/pages/research/index.html
@@ -13,7 +13,19 @@
       property="og:description"
       content="Research explorations and publications by Braeden Silver."
     />
-    <link rel="stylesheet" href="/assets/site.css" />
+    <link
+      rel="preload"
+      href="/assets/site.css"
+      as="style"
+      fetchpriority="high"
+    />
+    <link rel="stylesheet" href="/assets/site.css" fetchpriority="high" />
+    <link
+      rel="preload"
+      href="/js/site.js"
+      as="script"
+      fetchpriority="high"
+    />
   </head>
   <body data-section="research" data-content-render="research:index">
     <!-- ===== Shared layout containers (populated by js/site.js) ===== -->


### PR DESCRIPTION
## Summary
- add high-priority preload hints for the shared CSS/JS across site templates so navigation and layout render promptly
- simplify the bootstrap loader to defer the main bundle immediately while still respecting fetch priorities
- lazy-load the Giscus guest book with intersection observers and style its placeholder for accessibility
- tune media priorities (hero images, QR code, quick link icons) and enable content-visibility on long lists to preserve layout stability

## Testing
- not run (static content changes)


------
https://chatgpt.com/codex/tasks/task_e_68e556fa30e0833081c828138f52cba9